### PR TITLE
chore: Stripes-kint-components bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       ]
     },
     "dependencies": {
-      "@k-int/stripes-kint-components": "^2.8.2",
+      "@k-int/stripes-kint-components": "^3.0.4",
       "prop-types": "^15.6.0",
       "final-form": "^4.18.4",
       "final-form-arrays": "^3.0.1",


### PR DESCRIPTION
Bumped stripes-kint-components depenedency to 3.0.4, fixes breaking issue with useIntlKeyStore