### PR TITLE
fix: Serial info form tidy-up

### DIFF
--- a/src/components/SerialFormSections/SerialInfoForm/SerialInfoForm.js
+++ b/src/components/SerialFormSections/SerialInfoForm/SerialInfoForm.js
@@ -1,12 +1,7 @@
 import { Field } from 'react-final-form';
 import { FormattedMessage } from 'react-intl';
 
-import {
-  Row,
-  Col,
-  TextArea,
-  Select,
-} from '@folio/stripes/components';
+import { Row, Col, TextArea, Select } from '@folio/stripes/components';
 
 import { useSerialsManagementRefdata, selectifyRefdata } from '../../utils';
 
@@ -14,7 +9,6 @@ const [SERIAL_STATUS] = ['Serial.SerialStatus'];
 
 const SerialInfoForm = () => {
   const refdataValues = useSerialsManagementRefdata([SERIAL_STATUS]);
-  const statusValues = selectifyRefdata(refdataValues, SERIAL_STATUS);
 
   return (
     <Row>
@@ -32,9 +26,12 @@ const SerialInfoForm = () => {
       <Col xs={3}>
         <Field
           component={Select}
-          dataOptions={[{ value: '', label: '' }, ...statusValues]}
+          dataOptions={[
+            { value: '', label: '' },
+            ...selectifyRefdata(refdataValues, SERIAL_STATUS, 'value'),
+          ]}
           label={<FormattedMessage id="ui-serials-management.serials.status" />}
-          name="serialStatus.id"
+          name="serialStatus.value"
         />
       </Col>
     </Row>

--- a/src/routes/SerialCreateRoute/SerialCreateRoute.js
+++ b/src/routes/SerialCreateRoute/SerialCreateRoute.js
@@ -40,7 +40,13 @@ const SerialCreateRoute = () => {
 
   return (
     <>
-      <Form mutators={arrayMutators} onSubmit={submitSerial}>
+      <Form
+        initialValues={{
+          serialStatus: { value: 'active' },
+        }}
+        mutators={arrayMutators}
+        onSubmit={submitSerial}
+      >
         {({ handleSubmit }) => (
           <form onSubmit={handleSubmit}>
             <SerialForm

--- a/src/routes/SerialEditRoute/SerialEditRoute.js
+++ b/src/routes/SerialEditRoute/SerialEditRoute.js
@@ -38,7 +38,7 @@ const SerialEditRoute = () => {
   const submitSerial = async (values) => {
     const submitValues = {
       ...values,
-      ...(!values?.serialStatus?.id && { serialStatus: null }),
+      ...(!values?.serialStatus?.value && { serialStatus: null }),
       ...(values?.orderLine && {
         orderLine: { remoteId: values?.orderLine?.id },
       }),

--- a/src/routes/SerialEditRoute/SerialEditRoute.js
+++ b/src/routes/SerialEditRoute/SerialEditRoute.js
@@ -38,6 +38,7 @@ const SerialEditRoute = () => {
   const submitSerial = async (values) => {
     const submitValues = {
       ...values,
+      ...(!values?.serialStatus?.id && { serialStatus: null }),
       ...(values?.orderLine && {
         orderLine: { remoteId: values?.orderLine?.id },
       }),

--- a/src/routes/SerialsRoute/SerialsRoute.js
+++ b/src/routes/SerialsRoute/SerialsRoute.js
@@ -55,6 +55,14 @@ const SerialsRoute = ({ children, path }) => {
 
   const resultColumns = [
     {
+      propertyPath: 'serialStatus',
+      label: 'Status',
+    },
+    {
+      propertyPath: 'description',
+      label: 'Description',
+    },
+    {
       propertyPath: 'id',
       label: 'Serial ID',
     },
@@ -89,6 +97,7 @@ const SerialsRoute = ({ children, path }) => {
 
   const formatter = {
     id: (d) => d?.id,
+    serialStatus: (d) => d?.serialStatus?.label,
     // title: (d) => d?.id?.remoteId_object?.titleOrPackage,
     // productIds: (d) => d?.orderLine?.remoteId_object?.details?.productIds?.map((p) => p?.productId)?.join(';'),
     // poLineNumber: (d) => d?.orderLine?.remoteId_object?.poLineNumber,


### PR DESCRIPTION
Fixed ability for user to unset a serial status
Added temporary lookup columns to SASQLookup for serials
Refactored serial status field name to be based upon .value as opposed to .id for ease of use when handling initial values
Serial status now has initial value of 'active'

[UISER-1](https://issues.folio.org/browse/UISER-1)