### PR TITLE
fix: Fund link

### DIFF
--- a/src/components/SerialFormSections/POLineForm/POLineForm.js
+++ b/src/components/SerialFormSections/POLineForm/POLineForm.js
@@ -140,7 +140,7 @@ const POLineForm = () => {
                       ? values?.orderLine?.fundDistribution.map((fund) => {
                         return (
                           <li key={fund?.id}>
-                            <Link to={urls.fundView(fund?.id)}>
+                            <Link to={urls.fundView(fund?.fundId)}>
                               {fund?.code}
                             </Link>
                           </li>


### PR DESCRIPTION
Fixed fund link to use correctly named property "fund.fundId" as opposed to the incorrect "fund.id"