### PR TITLE
fix: IdentifierType/AcqUnit hook

### DIFF
--- a/src/hooks/useAcqUnits.js
+++ b/src/hooks/useAcqUnits.js
@@ -10,8 +10,11 @@ export const useAcqUnits = (acqUnitIds) => {
   const queryString =
     'id==(' + acqUnitIds?.map((e) => `"${e}"`).join(' or ') + ')';
 
+  // Using query string within query keys to ensure it is fired when acqUnits are changed
+  // May be a better alternative for acqUnitIds specified query keys
+
   const { isLoading, data = [] } = useQuery(
-    ['ui-serials-management', ACQUISITIONS_UNITS_API],
+    ['ui-serials-management', ACQUISITIONS_UNITS_API, queryString],
     () => ky.get(`${ACQUISITIONS_UNITS_API}?query=${queryString}`).json(),
     { enabled: !!acqUnitIds?.length }
   );

--- a/src/hooks/useIdentifierTypes.js
+++ b/src/hooks/useIdentifierTypes.js
@@ -7,8 +7,10 @@ import { IDENTIFIER_TYPES_ENDPOINT } from '../constants/endpoints';
 export const useIdentifierTypes = (identifierTypeIds) => {
   const ky = useOkapiKy();
 
+  const uniqueIdsArray = [...new Set(identifierTypeIds)];
+
   const queryString =
-    'id==(' + identifierTypeIds?.map((e) => `"${e}"`).join(' or ') + ')';
+    'id==(' + uniqueIdsArray?.map((e) => `"${e}"`).join(' or ') + ')';
 
   const { isLoading, data = [] } = useQuery(
     ['ui-serials-management', IDENTIFIER_TYPES_ENDPOINT],
@@ -18,7 +20,7 @@ export const useIdentifierTypes = (identifierTypeIds) => {
 
   return {
     isLoading,
-    data: data?.identifierTypes,
+    data: data?.identifierTypes || [],
   };
 };
 

--- a/src/hooks/useIdentifierTypes.js
+++ b/src/hooks/useIdentifierTypes.js
@@ -13,7 +13,7 @@ export const useIdentifierTypes = (identifierTypeIds) => {
   const { isLoading, data = [] } = useQuery(
     ['ui-serials-management', IDENTIFIER_TYPES_ENDPOINT],
     () => ky.get(`${IDENTIFIER_TYPES_ENDPOINT}?query=${queryString}`).json(),
-    { enabled: !!identifierTypeIds }
+    { enabled: !!identifierTypeIds?.length }
   );
 
   return {

--- a/src/hooks/useIdentifierTypes.js
+++ b/src/hooks/useIdentifierTypes.js
@@ -12,8 +12,11 @@ export const useIdentifierTypes = (identifierTypeIds) => {
   const queryString =
     'id==(' + uniqueIdsArray?.map((e) => `"${e}"`).join(' or ') + ')';
 
+  // Using query string within query keys to ensure it is fired when acqUnits are changed
+  // May be a better alternative for acqUnitIds specified query keys
+
   const { isLoading, data = [] } = useQuery(
-    ['ui-serials-management', IDENTIFIER_TYPES_ENDPOINT],
+    ['ui-serials-management', IDENTIFIER_TYPES_ENDPOINT, queryString],
     () => ky.get(`${IDENTIFIER_TYPES_ENDPOINT}?query=${queryString}`).json(),
     { enabled: !!identifierTypeIds?.length }
   );


### PR DESCRIPTION
- Fixed enabled flag to be correctly true/false based on type ids length as opposed to just existing, causing invalid fetches
- Added unique hook query keys to identifierType and acqUnit hooks to ensure fetch is refired each time the parameters passed are changed
- identiferTypeId array passed to identifier-type query is now unique, removing redundant duplicate ids within query string