### PR TITLE
chore: Stripes-kint-components bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "sinon": "^14.0.0"
   },
   "dependencies": {
-    "@k-int/stripes-kint-components": "^3.1.0",
+    "@k-int/stripes-kint-components": "^4.2.0",
     "prop-types": "^15.6.0",
     "final-form": "^4.18.4",
     "final-form-arrays": "^3.0.1",


### PR DESCRIPTION
Bumped stripes kint components dependency to 4.2.0