### PR TITLE
feat: Omission/Combination disabled

### DIFF
--- a/src/components/RulesetFormSections/CombinationFieldArray/CombinationFieldArray.js
+++ b/src/components/RulesetFormSections/CombinationFieldArray/CombinationFieldArray.js
@@ -1,4 +1,5 @@
 import { FieldArray } from 'react-final-form-arrays';
+import { useFormState } from 'react-final-form';
 import { FormattedMessage } from 'react-intl';
 
 import { Button } from '@folio/stripes/components';
@@ -9,6 +10,7 @@ import { useKiwtFieldArray } from '@k-int/stripes-kint-components';
 import CombinationField from '../CombinationField';
 
 const CombinationFieldArray = () => {
+  const { values } = useFormState();
   const { items, onAddField, onDeleteField } =
     useKiwtFieldArray('combination.rules');
 
@@ -42,7 +44,7 @@ const CombinationFieldArray = () => {
         })
         }
       </FieldArray>
-      <Button onClick={() => onAddField({})}>
+      <Button disabled={values?.omission} onClick={() => onAddField({})}>
         <FormattedMessage id="ui-serials-management.ruleset.addCombination" />
       </Button>
     </>

--- a/src/components/RulesetFormSections/OmissionFieldArray/OmissionFieldArray.js
+++ b/src/components/RulesetFormSections/OmissionFieldArray/OmissionFieldArray.js
@@ -1,4 +1,5 @@
 import { FieldArray } from 'react-final-form-arrays';
+import { useFormState } from 'react-final-form';
 import { FormattedMessage } from 'react-intl';
 
 import { Button } from '@folio/stripes/components';
@@ -9,7 +10,9 @@ import { useKiwtFieldArray } from '@k-int/stripes-kint-components';
 import OmissionField from '../OmissionField';
 
 const OmissionFieldArray = () => {
-  const { items, onAddField, onDeleteField } = useKiwtFieldArray('omission.rules');
+  const { values } = useFormState();
+  const { items, onAddField, onDeleteField } =
+    useKiwtFieldArray('omission.rules');
 
   return (
     <>
@@ -41,7 +44,7 @@ const OmissionFieldArray = () => {
         })
         }
       </FieldArray>
-      <Button onClick={() => onAddField({})}>
+      <Button disabled={values?.combination} onClick={() => onAddField({})}>
         <FormattedMessage id="ui-serials-management.ruleset.addOmission" />
       </Button>
     </>


### PR DESCRIPTION
Added conditionals to combinations/omissions field array to ensure that only one or the other can be added to ruleset at any time