### PR TITLE
fix: IssueWeekMonth omission field

### DIFF
--- a/src/components/RulesetFormSections/OmissionField/OmissionField.js
+++ b/src/components/RulesetFormSections/OmissionField/OmissionField.js
@@ -194,7 +194,7 @@ const OmissionsField = ({ name, index, omission }) => {
     issue_week_month: {
       fields: [
         renderIssueField(),
-        renderWeekField(1, 52, 'inWeek'),
+        renderWeekField(1, 4, 'inWeek'),
         renderMonthField('inMonth'),
       ],
     },


### PR DESCRIPTION
Updated max value for week field within IssueWeekMonth omission pattern to represent the weeks within a month as opposed to weeks within a year