### PR TITLE
feat: Hide "Days of publication, per cycle" section on a daily issue 

### DIFF
--- a/src/components/RulesetFormSections/CombinationField/CombinationField.js
+++ b/src/components/RulesetFormSections/CombinationField/CombinationField.js
@@ -182,12 +182,12 @@ const CombinationField = ({ name, index, combination }) => {
       fields: [renderIssueField()],
     },
     issue_week: {
-      fields: [renderIssueField(), renderWeekField(1, 52, 'ofWeek')],
+      fields: [renderIssueField(), renderWeekField(1, 52, 'inWeek')],
     },
     issue_week_month: {
       fields: [
         renderIssueField(),
-        renderWeekField(1, 4, 'ofWeek'),
+        renderWeekField(1, 4, 'inWeek'),
         renderMonthField('ofMonth'),
       ],
     },

--- a/src/components/RulesetFormSections/IssuePublicationFieldArray/IssuePublicationFieldArray.js
+++ b/src/components/RulesetFormSections/IssuePublicationFieldArray/IssuePublicationFieldArray.js
@@ -22,24 +22,37 @@ const IssuePublicationFieldArray = () => {
   const { change } = useForm();
   const patternTypes = useRecurrencePatternTypes();
 
+  // Check if the cycle length is a daily issue, defined by timeUnit="Day" and period=1
+  // This will cause the "Days of publication, per cycle" section not to render if so
+  const dailyIssueCheck = () => {
+    return (
+      values?.patternType === 'day' &&
+      (values?.recurrence?.period <= 1 || !values?.recurrence?.period)
+    );
+  };
+
   return (
     <>
-      <Row>
-        <Col xs={12}>
-          <Label tagName="h4">
-            <FormattedMessage id="ui-serials-management.ruleset.daysOfPublicationPerCycle" />
-            <InfoPopover
-              content={
-                <FormattedMessage
-                  id="ui-serials-management.ruleset.daysOfPublicationPerCyclePopover"
-                  values={{ br: <br /> }}
+      {!dailyIssueCheck() && (
+        <>
+          <Row>
+            <Col xs={12}>
+              <Label tagName="h4">
+                <FormattedMessage id="ui-serials-management.ruleset.daysOfPublicationPerCycle" />
+                <InfoPopover
+                  content={
+                    <FormattedMessage
+                      id="ui-serials-management.ruleset.daysOfPublicationPerCyclePopover"
+                      values={{ br: <br /> }}
+                    />
+                  }
                 />
-              }
-            />
-          </Label>
-        </Col>
-      </Row>
-      <br />
+              </Label>
+            </Col>
+          </Row>
+          <br />
+        </>
+      )}
       {!!patternTypes[values?.recurrence?.timeUnit?.value] && (
         <Row>
           <Col xs={3}>
@@ -78,28 +91,20 @@ const IssuePublicationFieldArray = () => {
           </Col>
         </Row>
       )}
-      {values?.patternType === 'day' &&
-      (values?.recurrence?.period <= 1 || !values?.recurrence?.period) ? (
-        <IssuePublicationField
-          index={0}
-          issue={items[0]}
-          name="recurrence.rules"
-          patternType={values?.patternType}
-        />
-        ) : (
-          <FieldArray name="recurrence.rules">
-            {() => items.map((issue, index) => {
-              return (
-                <IssuePublicationField
-                  index={index}
-                  name="recurrence.rules"
-                  patternType={values?.patternType}
-                />
-              );
-            })
+      {!dailyIssueCheck() && (
+        <FieldArray name="recurrence.rules">
+          {() => items.map((issue, index) => {
+            return (
+              <IssuePublicationField
+                index={index}
+                name="recurrence.rules"
+                patternType={values?.patternType}
+              />
+            );
+          })
           }
-          </FieldArray>
-        )}
+        </FieldArray>
+      )}
     </>
   );
 };

--- a/src/components/RulesetFormSections/OmissionField/OmissionField.js
+++ b/src/components/RulesetFormSections/OmissionField/OmissionField.js
@@ -189,12 +189,12 @@ const OmissionsField = ({ name, index, omission }) => {
       fields: [renderIssueField()],
     },
     issue_week: {
-      fields: [renderIssueField(), renderWeekField(1, 52, 'ofWeek')],
+      fields: [renderIssueField(), renderWeekField(1, 52, 'inWeek')],
     },
     issue_week_month: {
       fields: [
         renderIssueField(),
-        renderWeekField(1, 4, 'ofWeek'),
+        renderWeekField(1, 4, 'inWeek'),
         renderMonthField('ofMonth'),
       ],
     },


### PR DESCRIPTION
When a daily issue cycle is selected, deinfed by timeUnit=day and period=1, then the "Days of publication, per cycle" section will not be rendered

[UISER-26](https://issues.folio.org/browse/UISER-26)