### PR TITLE
fix: Time unit limiters safety check

### DIFF
--- a/src/components/RulesetFormSections/PatternTimePeriodForm/PatternTimePeriodForm.js
+++ b/src/components/RulesetFormSections/PatternTimePeriodForm/PatternTimePeriodForm.js
@@ -145,7 +145,7 @@ const PatternTimePeriodForm = () => {
               requiredValidator,
               validateWithinRange(
                 1,
-                TIME_UNIT_LIMITERS[values?.recurrence?.timeUnit?.value].period
+                TIME_UNIT_LIMITERS[values?.recurrence?.timeUnit?.value]?.period
               ),
               validateWholeNumber
             )}
@@ -204,7 +204,7 @@ const PatternTimePeriodForm = () => {
               requiredValidator,
               validateWithinRange(
                 1,
-                TIME_UNIT_LIMITERS[values?.recurrence?.timeUnit?.value].issues *
+                TIME_UNIT_LIMITERS[values?.recurrence?.timeUnit?.value]?.issues *
                   (values?.recurrence?.period || 1)
               ),
               validateWholeNumber


### PR DESCRIPTION
Added optional chaining to time unit limiters issues and period field to prevent crashing on empty form