### PR TITLE
feat: UI Changes

### DIFF
--- a/src/components/PieceSetSections/PieceSetInfo/PieceSetInfo.js
+++ b/src/components/PieceSetSections/PieceSetInfo/PieceSetInfo.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedDate } from 'react-intl';
 
 import { Row, Col, KeyValue } from '@folio/stripes/components';
+import { FormattedDateTime } from '@folio/stripes-erm-components';
 
 const propTypes = {
   pieceSet: PropTypes.object,
@@ -18,7 +19,7 @@ const PieceSetInfo = ({ pieceSet, id }) => {
               <FormattedMessage id="ui-serials-management.pieceSets.dateGenerated" />
             }
           >
-            <FormattedDate value={pieceSet?.dateCreated} />
+            <FormattedDateTime value={pieceSet?.dateCreated} />
           </KeyValue>
         </Col>
         <Col xs={3}>

--- a/src/components/PieceSetSections/PiecesList/PiecesList.js
+++ b/src/components/PieceSetSections/PiecesList/PiecesList.js
@@ -36,7 +36,7 @@ const PiecesList = ({ pieceSet, id }) => {
         </>
       );
     },
-    label: (e) => {
+    displaySummary: (e) => {
       return e?.label;
     },
   };
@@ -53,8 +53,8 @@ const PiecesList = ({ pieceSet, id }) => {
               publicationDate: (
                 <FormattedMessage id="ui-serials-management.pieceSets.publicationDate" />
               ),
-              label: (
-                <FormattedMessage id="ui-serials-management.pieceSets.label" />
+              displaySummary: (
+                <FormattedMessage id="ui-serials-management.pieceSets.displaySummary" />
               ),
               generatedInReceiving: (
                 <FormattedMessage id="ui-serials-management.pieceSets.generatedInReceiving" />
@@ -69,7 +69,7 @@ const PiecesList = ({ pieceSet, id }) => {
             visibleColumns={[
               'issueCount',
               'publicationDate',
-              'label',
+              'displaySummary',
               'generatedInReceiving',
             ]}
           />

--- a/src/components/PiecesPreviewModal/PiecesPreviewModal.js
+++ b/src/components/PiecesPreviewModal/PiecesPreviewModal.js
@@ -123,7 +123,7 @@ const PiecesPreviewModal = ({
         </>
       );
     },
-    label: (e) => {
+    displaySummary: (e) => {
       return e?.label;
     },
   };
@@ -140,8 +140,8 @@ const PiecesPreviewModal = ({
               publicationDate: (
                 <FormattedMessage id="ui-serials-management.ruleset.issuePublicationDate" />
               ),
-              label: (
-                <FormattedMessage id="ui-serials-management.piece.label" />
+              displaySummary: (
+                <FormattedMessage id="ui-serials-management.pieceSets.displaySummary" />
               ),
             }}
             columnWidths={{
@@ -150,7 +150,7 @@ const PiecesPreviewModal = ({
             contentData={predictedPieces}
             formatter={formatter}
             interactive={false}
-            visibleColumns={['issueCount', 'publicationDate', 'label']}
+            visibleColumns={['issueCount', 'publicationDate', 'displaySummary']}
           />
         </Col>
       </Row>

--- a/src/components/PiecesPreviewModal/PiecesPreviewModal.js
+++ b/src/components/PiecesPreviewModal/PiecesPreviewModal.js
@@ -219,20 +219,18 @@ const PiecesPreviewModal = ({
             validate={requiredValidator}
           />
         </Col>
+        {allowCreation && (
+          <Col xs={8}>
+            <Field
+              component={TextArea}
+              label={
+                <FormattedMessage id="ui-serials-management.pieceSets.note" />
+              }
+              name="note"
+            />
+          </Col>
+        )}
       </Row>
-      {allowCreation &&
-      <Row>
-        <Col xs={12}>
-          <Field
-            component={TextArea}
-            label={
-              <FormattedMessage id="ui-serials-management.pieceSets.note" />
-            }
-            name="note"
-          />
-        </Col>
-      </Row>
-}
       {!!predictedPieces && renderPiecesTable()}
     </FormModal>
   );

--- a/src/components/PiecesPreviewModal/PiecesPreviewModal.js
+++ b/src/components/PiecesPreviewModal/PiecesPreviewModal.js
@@ -15,6 +15,7 @@ import {
   Button,
   MultiColumnList,
   FormattedDate,
+  TextArea,
 } from '@folio/stripes/components';
 
 import { requiredValidator, InfoBox } from '@folio/stripes-erm-components';
@@ -68,6 +69,7 @@ const PiecesPreviewModal = ({
     const submitValues = {
       ruleset: { id: ruleset?.id },
       startDate: values?.startDate,
+      note: values?.note,
     };
     await createPieces(submitValues);
   };
@@ -218,6 +220,19 @@ const PiecesPreviewModal = ({
           />
         </Col>
       </Row>
+      {allowCreation &&
+      <Row>
+        <Col xs={12}>
+          <Field
+            component={TextArea}
+            label={
+              <FormattedMessage id="ui-serials-management.pieceSets.note" />
+            }
+            name="note"
+          />
+        </Col>
+      </Row>
+}
       {!!predictedPieces && renderPiecesTable()}
     </FormModal>
   );

--- a/src/components/SerialSections/ActivePublicationPattern/ActivePublicationPattern.js
+++ b/src/components/SerialSections/ActivePublicationPattern/ActivePublicationPattern.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/style-prop-object */
 import PropTypes from 'prop-types';
-import { FormattedMessage, FormattedDate } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { useLocation } from 'react-router-dom';
 
 import {
@@ -14,6 +14,8 @@ import {
   InfoPopover,
   MultiColumnList,
 } from '@folio/stripes/components';
+
+import { FormattedDateTime } from '@folio/stripes-erm-components';
 
 import { urls } from '../../utils';
 
@@ -37,7 +39,7 @@ const ActivePublicationPattern = ({ serial }) => {
       return e.rulesetNumber;
     },
     lastUpdated: (e) => {
-      return <FormattedDate value={e?.lastUpdated} />;
+      return <FormattedDateTime value={e?.lastUpdated} />;
     },
     description: (e) => {
       return e?.description;
@@ -92,7 +94,7 @@ const ActivePublicationPattern = ({ serial }) => {
                 label={
                   <FormattedMessage id="ui-serials-management.lastUpdated" />
                 }
-                value={<FormattedDate value={activeRuleset?.lastUpdated} />}
+                value={<FormattedDateTime value={activeRuleset?.lastUpdated} />}
               />
             </Col>
           </Row>

--- a/src/components/SerialSections/DeprecatedPublicationPatterns/DeprecatedPublicationPatterns.js
+++ b/src/components/SerialSections/DeprecatedPublicationPatterns/DeprecatedPublicationPatterns.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/style-prop-object */
 import PropTypes from 'prop-types';
-import { FormattedMessage, FormattedDate } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import {
   Accordion,
@@ -9,6 +9,8 @@ import {
   Row,
   MultiColumnList,
 } from '@folio/stripes/components';
+
+import { FormattedDateTime } from '@folio/stripes-erm-components';
 
 
 const proptypes = {
@@ -25,7 +27,7 @@ const DeprecatedPublicationPatterns = ({ serial }) => {
       return e.rulesetNumber;
     },
     lastUpdated: (e) => {
-      return <FormattedDate value={e?.lastUpdated} />;
+      return <FormattedDateTime value={e?.lastUpdated} />;
     },
     description: (e) => {
       return e?.description;

--- a/src/components/SerialSections/SerialPieceSets/SerialPieceSets.js
+++ b/src/components/SerialSections/SerialPieceSets/SerialPieceSets.js
@@ -1,0 +1,89 @@
+/* eslint-disable react/style-prop-object */
+import PropTypes from 'prop-types';
+import { FormattedMessage, FormattedDate } from 'react-intl';
+
+import {
+  Accordion,
+  Badge,
+  Col,
+  Row,
+  MultiColumnList,
+} from '@folio/stripes/components';
+import { useHistory } from 'react-router-dom/cjs/react-router-dom.min';
+
+const proptypes = {
+  pieceSets: PropTypes.arrayOf(PropTypes.object),
+};
+
+const SerialPieceSets = ({ pieceSets }) => {
+  const history = useHistory();
+
+  const renderBadge = () => {
+    return <Badge>{pieceSets?.length}</Badge>;
+  };
+
+  const formatter = {
+    dateGenerated: (p) => {
+      return p.dateCreated;
+    },
+    startDate: (p) => {
+      return <FormattedDate value={p?.startDate} />;
+    },
+    patternId: (p) => p?.ruleset?.rulesetNumber,
+    total: (p) => p?.pieces?.length,
+    note: (p) => p?.note,
+  };
+
+  return (
+    <Accordion
+      closedByDefault
+      displayWhenClosed={renderBadge()}
+      displayWhenOpen={renderBadge()}
+      label={
+        <FormattedMessage id="ui-serials-management.pieceSets.predictedPieceSets" />
+      }
+    >
+      <Row>
+        <Col xs={12}>
+          <MultiColumnList
+            columnMapping={{
+              dateGenerated: (
+                <FormattedMessage id="ui-serials-management.pieceSets.dateGenerated" />
+              ),
+              startDate: (
+                <FormattedMessage id="ui-serials-management.pieceSets.startDate" />
+              ),
+              patternId: (
+                <FormattedMessage id="ui-serials-management.pieceSets.patternId" />
+              ),
+              total: (
+                <FormattedMessage id="ui-serials-management.pieceSets.total" />
+              ),
+              note: (
+                <FormattedMessage id="ui-serials-management.pieceSets.note" />
+              ),
+            }}
+            // Column width needs to be updated with correct value when formatted time is implemented
+            columnWidths={{
+              dateGenerated: 170,
+            }}
+            contentData={pieceSets}
+            formatter={formatter}
+            interactive={false}
+            visibleColumns={[
+              'dateGenerated',
+              'startDate',
+              'patternId',
+              'total',
+              'note',
+            ]}
+          />
+        </Col>
+      </Row>
+    </Accordion>
+  );
+};
+
+SerialPieceSets.propTypes = proptypes;
+
+export default SerialPieceSets;

--- a/src/components/SerialSections/SerialPieceSets/SerialPieceSets.js
+++ b/src/components/SerialSections/SerialPieceSets/SerialPieceSets.js
@@ -1,6 +1,6 @@
-/* eslint-disable react/style-prop-object */
 import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedDate } from 'react-intl';
+import { Link } from 'react-router-dom';
 
 import {
   Accordion,
@@ -9,22 +9,28 @@ import {
   Row,
   MultiColumnList,
 } from '@folio/stripes/components';
-import { useHistory } from 'react-router-dom/cjs/react-router-dom.min';
+import { FormattedDateTime } from '@folio/stripes-erm-components';
+
+import { urls } from '../../utils';
 
 const proptypes = {
   pieceSets: PropTypes.arrayOf(PropTypes.object),
 };
 
 const SerialPieceSets = ({ pieceSets }) => {
-  const history = useHistory();
-
   const renderBadge = () => {
     return <Badge>{pieceSets?.length}</Badge>;
   };
 
   const formatter = {
     dateGenerated: (p) => {
-      return p.dateCreated;
+      return (
+        <>
+          <Link to={urls.pieceSetView(p?.id)}>
+            <FormattedDateTime value={p?.dateCreated} />
+          </Link>
+        </>
+      );
     },
     startDate: (p) => {
       return <FormattedDate value={p?.startDate} />;

--- a/src/components/SerialSections/SerialPieceSets/index.js
+++ b/src/components/SerialSections/SerialPieceSets/index.js
@@ -1,0 +1,1 @@
+export { default } from './SerialPieceSets';

--- a/src/components/SerialSections/index.js
+++ b/src/components/SerialSections/index.js
@@ -2,3 +2,4 @@ export { default as SerialInfo } from './SerialInfo';
 export { default as SerialPOLine } from './SerialPOLine';
 export { default as ActivePublicationPattern } from './ActivePublicationPattern';
 export { default as DeprecatedPublicationPatterns } from './DeprecatedPublicationPatterns';
+export { default as SerialPieceSets } from './SerialPieceSets';

--- a/src/components/views/PieceSetView/PieceSetView.js
+++ b/src/components/views/PieceSetView/PieceSetView.js
@@ -76,6 +76,7 @@ const PieceSetView = ({
         defaultWidth={DEFAULT_VIEW_PANE_WIDTH}
         dismissible
         onClose={onClose}
+        paneTitle={serial?.orderLine?.title}
       >
         <PieceSetInfo {...getSectionProps('info')} />
         <PiecesList {...getSectionProps('pieces-list')} />

--- a/src/components/views/SerialView/SerialView.js
+++ b/src/components/views/SerialView/SerialView.js
@@ -1,9 +1,10 @@
 import { createRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { useQuery } from 'react-query';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 
-import { useStripes } from '@folio/stripes/core';
+import { useOkapiKy, useStripes } from '@folio/stripes/core';
 import {
   Pane,
   LoadingPane,
@@ -23,10 +24,12 @@ import {
   DeprecatedPublicationPatterns,
   SerialInfo,
   SerialPOLine,
+  SerialPieceSets,
 } from '../../SerialSections';
 import PiecesPreviewModal from '../../PiecesPreviewModal';
 import { urls } from '../../utils';
 import { DEFAULT_VIEW_PANE_WIDTH } from '../../../constants/config';
+import { PIECE_SETS_ENDPOINT } from '../../../constants/endpoints';
 
 const propTypes = {
   onClose: PropTypes.func.isRequired,
@@ -44,8 +47,16 @@ const SerialView = ({
   const params = useParams();
   const stripes = useStripes();
   const accordionStatusRef = createRef();
+  const ky = useOkapiKy();
 
   const [showModal, setShowModal] = useState(false);
+
+  const { data: pieceSets, pieceSetsLoading } = useQuery(
+    ['ui-serials-management', 'SerialView', serial?.id],
+    () => ky
+      .get(`${PIECE_SETS_ENDPOINT}?filters=ruleset.owner.id==${serial?.id}`)
+      .json()
+  );
 
   const handleEdit = () => {
     history.push(`${urls.serialEdit(params?.id)}${location.search}`);
@@ -139,6 +150,12 @@ const SerialView = ({
               ) && (
                 <DeprecatedPublicationPatterns
                   {...getSectionProps('deprecated-publication-pattern')}
+                />
+              )}
+              {pieceSets && !pieceSetsLoading && (
+                <SerialPieceSets
+                  id="serial-section-serial-piece-sets"
+                  pieceSets={pieceSets}
                 />
               )}
             </AccordionSet>

--- a/src/components/views/SerialView/SerialView.js
+++ b/src/components/views/SerialView/SerialView.js
@@ -152,7 +152,7 @@ const SerialView = ({
                   {...getSectionProps('deprecated-publication-pattern')}
                 />
               )}
-              {pieceSets && !pieceSetsLoading && (
+              {!!pieceSets?.length && !pieceSetsLoading && (
                 <SerialPieceSets
                   id="serial-section-serial-piece-sets"
                   pieceSets={pieceSets}

--- a/src/routes/PieceSetsRoute/PieceSetsRoute.js
+++ b/src/routes/PieceSetsRoute/PieceSetsRoute.js
@@ -2,7 +2,10 @@ import PropTypes from 'prop-types';
 
 import { FormattedMessage, FormattedDate } from 'react-intl';
 
+import { FormattedDateTime } from '@folio/stripes-erm-components';
+
 import { SASQRoute } from '@k-int/stripes-kint-components';
+
 import { PieceSetView } from '../../components/views';
 import { RouteSwitcher } from '../../components/SearchAndFilter';
 
@@ -54,7 +57,7 @@ const PieceSetsRoute = ({ children, path }) => {
 
   const formatter = {
     dateCreated: (d) => {
-      return <FormattedDate value={d?.dateCreated} />;
+      return <FormattedDateTime value={d?.dateCreated} />;
     },
     // title: (d) => d?.id?.remoteId_object?.titleOrPackage,
     total: (d) => d?.pieces?.length,

--- a/translations/ui-serials-management/en.json
+++ b/translations/ui-serials-management/en.json
@@ -166,7 +166,7 @@
   "pieceSets.note": "Note",
   "pieceSets.totalPieces": "Total pieces",
   "pieceSets.issueCount": "Issue count",
-  "pieceSets.label": "Label",
+  "pieceSets.displaySummary": "Display summary",
   "pieceSets.publicationDate": "Publication date",
   "pieceSets.generatedInReceiving": "Generated in receiving",
   "pieceSets.omitted": "Omitted",

--- a/translations/ui-serials-management/en_US.json
+++ b/translations/ui-serials-management/en_US.json
@@ -151,7 +151,6 @@
     "pieceSets.note": "Note",
     "pieceSets.totalPieces": "Total pieces",
     "pieceSets.issueCount": "Issue count",
-    "pieceSets.label": "Label",
     "pieceSets.publicationDate": "Publication date",
     "pieceSets.generatedInReceiving": "Generated in receiving",
     "ruleset.numberOfIssuesPerCycle": "No. of issues published per cycle",


### PR DESCRIPTION
- Added note field to predicted piece set generation modal
- Updated label fields within piece sets preview and view to be display summary
- Added predicted piece sets that are associated with a serial to the serial view pane
- Added link to predicted piece set from serials piece sets MCL, also updated multiple last updated or date generated fields to use FormattedDateTime, instead of FormattedDate
- Added serials associated title to the piece sets pane header
- Fixed conditional for hiding piece sets within serial view


[UISER-50](https://folio-org.atlassian.net/browse/UISER-50), [UISER-46](https://folio-org.atlassian.net/browse/UISER-46), [UISER-56](https://folio-org.atlassian.net/browse/UISER-56)
