### PR TITLE
fix: Enumeration textual translations

### DIFF
--- a/src/components/RulesetFormSections/EnumerationTextualFieldArray/EnumerationTextualFieldArray.js
+++ b/src/components/RulesetFormSections/EnumerationTextualFieldArray/EnumerationTextualFieldArray.js
@@ -39,7 +39,7 @@ const EnumerationTextualFieldArray = ({ name }) => {
                 dataOptions={[{ label: '', value: '' }, ...refdataOptions]}
                 input={input}
                 label={
-                  <FormattedMessage id="ui-serials-management.ruleset.refdataCategory" />
+                  <FormattedMessage id="ui-serials-management.ruleset.pickList" />
                 }
                 meta={meta}
                 onChange={(e) => {
@@ -107,7 +107,7 @@ const EnumerationTextualFieldArray = ({ name }) => {
         }
       </FieldArray>
       <Button onClick={() => onAddField({})}>
-        <FormattedMessage id="ui-serials-management.ruleset.addLevel" />
+        <FormattedMessage id="ui-serials-management.ruleset.addValue" />
       </Button>
     </>
   );

--- a/translations/ui-serials-management/en.json
+++ b/translations/ui-serials-management/en.json
@@ -151,6 +151,7 @@
   "ruleset.monthFormat": "Month format",
   "ruleset.yearFormat": "Year format",
   "ruleset.addLevel": "Add level",
+  "ruleset.addValue": "Add value",
   "ruleset.level": "Level",
   "ruleset.levelIndex": "Level {index}",
   "ruleset.format": "Format",
@@ -164,7 +165,7 @@
   "ruleset.numberOfIssues": "No. of issues",
   "ruleset.numberOfUnits": "No. of units",
   "ruleset.valuesToUseForFirstIssue": "Values to use for the first issue",
-  "ruleset.refdataCategory": "Refdata category",
+  "ruleset.pickList": "Pick list",
   
   "pieceSets": "Piece sets",
   "pieceSets.predictedPieceSets": "Predicted piece sets",

--- a/translations/ui-serials-management/en_US.json
+++ b/translations/ui-serials-management/en_US.json
@@ -177,7 +177,7 @@
     "pieceSets.displaySummary": "Display summary",
     "ruleset.levelIndex": "Level {index}",
     "ruleset.valuesToUseForFirstIssue": "Values to use for the first issue",
-    "ruleset.refdataCategory": "Refdata category",
+    "ruleset.pickList": "Pick list",
     "refdataCategory.refdataCategory": "Category",
     "refdataCategory.noOfValues": "# of values",
     "refdataCategory.refdataCategories": "Categories",


### PR DESCRIPTION
Changed labels within enumeration textual field array, "refdata category" is now "picklist" and "add level" is now "add value"

[UISER-96](https://folio-org.atlassian.net/browse/UISER-96), [UISER-97](https://folio-org.atlassian.net/browse/UISER-97)