### PR TITLE
fix: Preview pieces modal

### DIFF
--- a/src/components/PiecesPreviewModal/PiecesPreviewModal.js
+++ b/src/components/PiecesPreviewModal/PiecesPreviewModal.js
@@ -260,7 +260,7 @@ const PiecesPreviewModal = ({
           </div>
         )}
         <Button
-          buttonStyle="default"
+          buttonStyle={allowCreation ? 'default' : 'primary'}
           disabled={submitting || invalid || pristine}
           marginBottom0
           onClick={() => handleGeneration(values)}

--- a/src/components/views/SerialView/SerialView.js
+++ b/src/components/views/SerialView/SerialView.js
@@ -99,7 +99,9 @@ const SerialView = ({
         buttons.push(
           <Button
             buttonStyle="dropdownItem"
-            disabled={!serial?.serialRulesets}
+            disabled={!serial?.serialRulesets?.some(
+              (sr) => sr?.rulesetStatus?.value === 'active'
+            )}
             id="clickable-dropdown-generate-pieces"
             onClick={() => setShowModal(true)}
           >


### PR DESCRIPTION
Generate modal button is now primary when the only button within the footer, additionally ensured that pieces cannot be generated if no active ruleset is present

[UISER-72](https://folio-org.atlassian.net/browse/UISER-72)