### PR TITLE
fix: Enumeration numeric field tweaks

### DIFF
--- a/src/components/RulesetFormSections/EnumerationNumericField/EnumerationNumericField.js
+++ b/src/components/RulesetFormSections/EnumerationNumericField/EnumerationNumericField.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-
+import { FormattedMessage } from 'react-intl';
 import { Field } from 'react-final-form';
 
 import {
@@ -10,11 +10,17 @@ import {
   IconButton,
 } from '@folio/stripes/components';
 
-import { requiredValidator } from '@folio/stripes-erm-components';
-
-import { useSerialsManagementRefdata, selectifyRefdata } from '../../utils';
+import {
+  requiredValidator,
+  composeValidators,
+} from '@folio/stripes-erm-components';
 
 import { ENUMERATION_NUMBER_FORMAT } from '../../../constants/selectOptionTranslations';
+import {
+  validateWholeNumber,
+  useSerialsManagementRefdata,
+  selectifyRefdata,
+} from '../../utils';
 
 const [ENUMERATION_FORMAT, ENUMERATION_SEQUENCE] = [
   'EnumerationNumericLevelTMRF.Format',
@@ -32,47 +38,86 @@ const EnumerationNumericField = ({
     ENUMERATION_FORMAT,
     ENUMERATION_SEQUENCE,
   ]);
+
   return (
     <Row>
       <Col xs={1}>{index + 1}</Col>
       <Col xs={2}>
-        <Field component={TextField} name={`${name}.units`} />
+        <FormattedMessage id="ui-serials-management.ruleset.format">
+          {(ariaLabel) => (
+            <Field
+              aria-label={ariaLabel}
+              component={TextField}
+              name={`${name}.units`}
+              required
+              type="number"
+              validate={composeValidators(
+                requiredValidator,
+                validateWholeNumber
+              )}
+            />
+          )}
+        </FormattedMessage>
       </Col>
       <Col xs={2}>
-        <Field
-          component={Select}
-          dataOptions={[
-            { value: '', label: '' },
-            ...selectifyRefdata(refdataValues, ENUMERATION_FORMAT, 'value').map(
-              (o) => {
-                return {
-                  value: o?.value,
-                  label: ENUMERATION_NUMBER_FORMAT?.find(
-                    (e) => e?.value === o?.value
-                  )?.label,
-                };
-              }
-            ),
-          ]}
-          name={`${name}.format.value`}
-          required
-          validate={requiredValidator}
-        />
+        <FormattedMessage id="ui-serials-management.ruleset.format">
+          {(ariaLabel) => (
+            <Field
+              aria-label={`level-${index + 1}-${ariaLabel}`}
+              component={Select}
+              dataOptions={[
+                { value: '', label: '' },
+                ...selectifyRefdata(
+                  refdataValues,
+                  ENUMERATION_FORMAT,
+                  'value'
+                ).map((o) => {
+                  return {
+                    value: o?.value,
+                    label: ENUMERATION_NUMBER_FORMAT?.find(
+                      (e) => e?.value === o?.value
+                    )?.label,
+                  };
+                }),
+              ]}
+              name={`${name}.format.value`}
+              required
+              validate={requiredValidator}
+            />
+          )}
+        </FormattedMessage>
       </Col>
       <Col xs={2}>
-        <Field
-          component={Select}
-          dataOptions={[
-            { value: '', label: '' },
-            ...selectifyRefdata(refdataValues, ENUMERATION_SEQUENCE, 'value'),
-          ]}
-          name={`${name}.sequence.value`}
-          required
-          validate={requiredValidator}
-        />
+        <FormattedMessage id="ui-serials-management.ruleset.sequence">
+          {(ariaLabel) => (
+            <Field
+              aria-label={`level-${index + 1}-${ariaLabel}`}
+              component={Select}
+              dataOptions={[
+                { value: '', label: '' },
+                ...selectifyRefdata(
+                  refdataValues,
+                  ENUMERATION_SEQUENCE,
+                  'value'
+                ),
+              ]}
+              name={`${name}.sequence.value`}
+              required
+              validate={requiredValidator}
+            />
+          )}
+        </FormattedMessage>
       </Col>
       <Col xs={3}>
-        <Field component={TextField} name={`${name}.internalNote`} />
+        <FormattedMessage id="ui-serials-management.ruleset.internalNote">
+          {(ariaLabel) => (
+            <Field
+              aria-label={ariaLabel}
+              component={TextField}
+              name={`${name}.internalNote`}
+            />
+          )}
+        </FormattedMessage>
       </Col>
       {items?.length > 1 && (
         <Col xs={2}>


### PR DESCRIPTION
Number of units field within enumeration numeric field is now validated as required and a whole number, additionally added aria labels to all associated fields

[UISER-67](https://folio-org.atlassian.net/browse/UISER-67), [UISER-103](https://folio-org.atlassian.net/browse/UISER-103)