### PR TITLE
fix: Serial view missing elements

### DIFF
--- a/src/components/views/SerialView/SerialView.js
+++ b/src/components/views/SerialView/SerialView.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { useQuery } from 'react-query';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 
-import { useOkapiKy, useStripes } from '@folio/stripes/core';
+import { AppIcon, useOkapiKy, useStripes } from '@folio/stripes/core';
 import {
   Pane,
   LoadingPane,
@@ -99,9 +99,11 @@ const SerialView = ({
         buttons.push(
           <Button
             buttonStyle="dropdownItem"
-            disabled={!serial?.serialRulesets?.some(
-              (sr) => sr?.rulesetStatus?.value === 'active'
-            )}
+            disabled={
+              !serial?.serialRulesets?.some(
+                (sr) => sr?.rulesetStatus?.value === 'active'
+              )
+            }
             id="clickable-dropdown-generate-pieces"
             onClick={() => setShowModal(true)}
           >
@@ -128,9 +130,36 @@ const SerialView = ({
       >
         <Pane
           actionMenu={renderActionMenu}
+          appIcon={
+            <AppIcon app="serials-management" iconKey="app" size="small" />
+          }
           defaultWidth={DEFAULT_VIEW_PANE_WIDTH}
           dismissible
           onClose={onClose}
+          paneSub={
+            serial?.orderLine?.remoteId_object?.poLineNumber && (
+              <>
+                <FormattedMessage id="ui-serials-management.poLine" />
+                {' - '}
+                {serial.orderLine.remoteId_object.poLineNumber}
+              </>
+            )
+          }
+          paneTitle={
+            serial?.orderLine?.title ? (
+              <>
+                <FormattedMessage id="ui-serials-management.serials.title" />
+                {' - '}
+                {serial?.orderLine?.title}
+              </>
+            ) : (
+              <>
+                <FormattedMessage id="ui-serials-management.serials.serial" />
+                {' - '}
+                {serial?.id}
+              </>
+            )
+          }
         >
           <MetaSection
             contentId="serialMetaContent"

--- a/translations/ui-serials-management/en.json
+++ b/translations/ui-serials-management/en.json
@@ -36,6 +36,7 @@
   "settings.refdata.pickLists": "Pick lists",
 
   "serials": "Serials",
+  "serials.serial": "Serial",
   "serials.newSerial": "New serial",
   "serials.editSerial": "Edit serial",
   "serials.poLineNumber": "PO line number",


### PR DESCRIPTION
Added serial app logo, serial title and poline number to serial view pane header and sub header along with fallbacks for if a poline has not been attached to the serial

[UISER-65](https://folio-org.atlassian.net/browse/UISER-65)