### PR TITLE
fix: Accessibility omissions/combinations accordions

### DIFF
--- a/src/components/RulesetFormSections/CombinationFieldArray/CombinationFieldArray.js
+++ b/src/components/RulesetFormSections/CombinationFieldArray/CombinationFieldArray.js
@@ -2,7 +2,14 @@ import { FieldArray } from 'react-final-form-arrays';
 import { useFormState, Field, useForm } from 'react-final-form';
 import { FormattedMessage } from 'react-intl';
 
-import { Button, Select, Row, Col, Tooltip } from '@folio/stripes/components';
+import {
+  Button,
+  Select,
+  Row,
+  Col,
+  Tooltip,
+  InfoPopover,
+} from '@folio/stripes/components';
 import { EditCard, requiredValidator } from '@folio/stripes-erm-components';
 
 import { useKiwtFieldArray } from '@k-int/stripes-kint-components';
@@ -64,10 +71,22 @@ const CombinationFieldArray = () => {
           />
         }
         header={
-          <FormattedMessage
-            id="ui-serials-management.ruleset.combinationRuleIndex"
-            values={{ index: index + 1 }}
-          />
+          <>
+            <FormattedMessage
+              id="ui-serials-management.ruleset.combinationRuleIndex"
+              values={{ index: index + 1 }}
+            />
+            <InfoPopover
+              content={
+                <FormattedMessage
+                  id="ui-serials-management.ruleset.combinationRulesPopover"
+                  values={{
+                    br: <br />,
+                  }}
+                />
+              }
+            />
+          </>
         }
         onDelete={() => onDeleteField(index, combination)}
       >

--- a/src/components/RulesetFormSections/OmissionFieldArray/OmissionFieldArray.js
+++ b/src/components/RulesetFormSections/OmissionFieldArray/OmissionFieldArray.js
@@ -2,7 +2,14 @@ import { FieldArray } from 'react-final-form-arrays';
 import { useFormState, Field, useForm } from 'react-final-form';
 import { FormattedMessage } from 'react-intl';
 
-import { Button, Select, Row, Col, Tooltip } from '@folio/stripes/components';
+import {
+  Button,
+  Select,
+  Row,
+  Col,
+  Tooltip,
+  InfoPopover,
+} from '@folio/stripes/components';
 import { EditCard, requiredValidator } from '@folio/stripes-erm-components';
 
 import { useKiwtFieldArray } from '@k-int/stripes-kint-components';
@@ -64,10 +71,22 @@ const OmissionFieldArray = () => {
           />
         }
         header={
-          <FormattedMessage
-            id="ui-serials-management.ruleset.omissionRuleIndex"
-            values={{ index: index + 1 }}
-          />
+          <>
+            <FormattedMessage
+              id="ui-serials-management.ruleset.omissionRuleIndex"
+              values={{ index: index + 1 }}
+            />
+            <InfoPopover
+              content={
+                <FormattedMessage
+                  id="ui-serials-management.ruleset.omissionRulesPopover"
+                  values={{
+                    br: <br />,
+                  }}
+                />
+              }
+            />
+          </>
         }
         onDelete={() => onDeleteField(index, omission)}
       >

--- a/src/components/views/RulesetForm/RulesetForm.js
+++ b/src/components/views/RulesetForm/RulesetForm.js
@@ -22,7 +22,6 @@ import {
   expandAllSections,
   collapseAllSections,
   checkScope,
-  InfoPopover,
 } from '@folio/stripes/components';
 
 import { handleSaveKeyCommand } from '../../utils';
@@ -167,38 +166,14 @@ const RulesetForm = ({ handlers: { onClose, onSubmit } }) => {
               </Accordion>
               <Accordion
                 label={
-                  <>
-                    <FormattedMessage id="ui-serials-management.ruleset.omissionRules" />
-                    <InfoPopover
-                      content={
-                        <FormattedMessage
-                          id="ui-serials-management.ruleset.omissionRulesPopover"
-                          values={{
-                            br: <br />,
-                          }}
-                        />
-                      }
-                    />
-                  </>
+                  <FormattedMessage id="ui-serials-management.ruleset.omissionRules" />
                 }
               >
                 <OmissionFieldArray />
               </Accordion>
               <Accordion
                 label={
-                  <>
-                    <FormattedMessage id="ui-serials-management.ruleset.combinationRules" />
-                    <InfoPopover
-                      content={
-                        <FormattedMessage
-                          id="ui-serials-management.ruleset.combinationRulesPopover"
-                          values={{
-                            br: <br />,
-                          }}
-                        />
-                      }
-                    />
-                  </>
+                  <FormattedMessage id="ui-serials-management.ruleset.combinationRules" />
                 }
               >
                 <CombinationFieldArray />


### PR DESCRIPTION
Fixed an accessibility issue “Interactive controls must not be nested” with the omissions and combinations accordions

uiser-66