### PR TITLE
UISER-95: Add refdata read permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,10 @@
     "permissionSets": [
       {
         "permissionName": "module.serials-management.enabled",
-        "displayName": "UI: ui-serials-management module is enabled"
+        "displayName": "UI: ui-serials-management module is enabled",
+        "subPermissions": [
+          "serials-management.refdata.read"
+        ]
       },
       {
         "permissionName": "settings.serials-management.enabled",


### PR DESCRIPTION
Ensures that all users of the serials module can read refdata (for dropdown lists etc.)