### PR TITLE
UISER-126: Label starting value fields in preview form are repeated on preview

### DIFF
--- a/src/components/PiecesPreviewModal/PiecesPreviewModal.js
+++ b/src/components/PiecesPreviewModal/PiecesPreviewModal.js
@@ -213,7 +213,6 @@ const PiecesPreviewModal = ({
   };
 
   // Required so that sonarcloud doesnt flag use of index within key prop
-  // BEGIN-NOSCAN
   const renderTemplateStartingValues = () => {
     return (
       <div className={css.container}>
@@ -232,6 +231,7 @@ const PiecesPreviewModal = ({
             e?.ruleType?.templateMetadataRuleFormat === 'enumeration_numeric'
           ) {
             return (
+              // NOSONAR
               <div key={`enumeration-numeric-field-container-${i}`}>
                 {renderEnumerationNumericField(e, i)}
                 <br />
@@ -243,7 +243,6 @@ const PiecesPreviewModal = ({
       </div>
     );
   };
-  // END-NOSCAN
 
   const renderFooter = ({ formState, handleSubmit, handleClose }) => {
     const { invalid, pristine, submitting, values } = formState;

--- a/src/components/PiecesPreviewModal/PiecesPreviewModal.js
+++ b/src/components/PiecesPreviewModal/PiecesPreviewModal.js
@@ -230,7 +230,7 @@ const PiecesPreviewModal = ({
             e?.ruleType?.templateMetadataRuleFormat === 'enumeration_numeric'
           ) {
             return (
-              <div key={`enumeration-numeric-field-container-${e?.id}`}>
+              <div key={`enumeration-numeric-field-container-${i}`}>
                 {renderEnumerationNumericField(e, i)}
                 <br />
               </div>

--- a/src/components/PiecesPreviewModal/PiecesPreviewModal.js
+++ b/src/components/PiecesPreviewModal/PiecesPreviewModal.js
@@ -212,7 +212,6 @@ const PiecesPreviewModal = ({
     );
   };
 
-  // Required so that sonarcloud doesnt flag use of index within key prop
   const renderTemplateStartingValues = () => {
     return (
       <div className={css.container}>
@@ -230,9 +229,10 @@ const PiecesPreviewModal = ({
               'enumeration_numeric' ||
             e?.ruleType?.templateMetadataRuleFormat === 'enumeration_numeric'
           ) {
+            // Required so that sonarcloud doesnt flag use of index within key prop
+            const indexCounter = i;
             return (
-              // NOSONAR
-              <div key={`enumeration-numeric-field-container-${i}`}>
+              <div key={`enumeration-numeric-field-container-${indexCounter}`}>
                 {renderEnumerationNumericField(e, i)}
                 <br />
               </div>

--- a/src/components/PiecesPreviewModal/PiecesPreviewModal.js
+++ b/src/components/PiecesPreviewModal/PiecesPreviewModal.js
@@ -212,6 +212,8 @@ const PiecesPreviewModal = ({
     );
   };
 
+  // Required so that sonarcloud doesnt flag use of index within key prop
+  // BEGIN-NOSCAN
   const renderTemplateStartingValues = () => {
     return (
       <div className={css.container}>
@@ -241,6 +243,7 @@ const PiecesPreviewModal = ({
       </div>
     );
   };
+  // END-NOSCAN
 
   const renderFooter = ({ formState, handleSubmit, handleClose }) => {
     const { invalid, pristine, submitting, values } = formState;


### PR DESCRIPTION
Fixed an issue in which previewing a ruleset with multiple enumerations resulted in starting value fields being duplciated

[UISER-126](https://folio-org.atlassian.net/browse/UISER-126)