### PR TITLE
UISER-13 UX updates: New/Edit Serial

### DIFF
--- a/src/components/PiecePublicationDate/PiecePublicationDate.test.js
+++ b/src/components/PiecePublicationDate/PiecePublicationDate.test.js
@@ -1,7 +1,14 @@
 import { renderWithIntl } from '@folio/stripes-erm-testing';
-
 import PiecePublicationDate from './PiecePublicationDate';
 import { translationsProperties } from '../../../test/helpers';
+
+function getCurrentFormattedDate() {
+  const date = new Date();
+  const formattedDate = `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
+  return formattedDate;
+}
+
+const expectedDate = getCurrentFormattedDate();
 
 const recurrencePiece = {
   piece: {
@@ -43,7 +50,7 @@ describe('PiecePublicationDate', () => {
 
     test('renders the expected date value', async () => {
       const { getByText } = renderComponent;
-      expect(getByText('4/15/2024')).toBeInTheDocument();
+      expect(getByText(expectedDate)).toBeInTheDocument();
     });
   });
 
@@ -58,7 +65,7 @@ describe('PiecePublicationDate', () => {
 
     test('renders the expected date value', async () => {
       const { getByText } = renderComponent;
-      expect(getByText('4/15/2024')).toBeInTheDocument();
+      expect(getByText(expectedDate)).toBeInTheDocument();
     });
 
     test('renders the Omitted', async () => {

--- a/src/components/SerialFormSections/POLineForm/POLineForm.js
+++ b/src/components/SerialFormSections/POLineForm/POLineForm.js
@@ -3,6 +3,8 @@ import { Field, useFormState, useForm } from 'react-final-form';
 import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
 
+import isEqual from 'lodash/isEqual';
+
 import { Row, Col, KeyValue } from '@folio/stripes/components';
 import { AppIcon } from '@folio/stripes/core';
 
@@ -24,9 +26,16 @@ const POLineForm = () => {
 
   // istanbul ignore next
   useEffect(() => {
-    if (values?.orderLine && !titlesLoading) {
-      if (values?.title !== titles?.titles[0] && titles?.titles?.length === 1) {
-        change('orderLine.titleObject', titles?.titles[0]);
+    if (
+      values?.orderLine &&
+      !titlesLoading &&
+      titles?.titles?.length === 1
+    ) {
+      const titleObj = { id: titles.titles[0].id, title: titles.titles[0].title };
+      if (!isEqual(values.orderLine?.titleObject, titleObj)) {
+        // Ensure same shape as initialValues -- THIS IS FLAKY -- WE SHOULD BE DOING SOMETHING CLEVERER HERE
+        // Don't use form state here mabe, track this kind of extra difference through our own state? -- Investigate
+        change('orderLine.titleObject', titleObj);
       }
     }
   }, [change, titles?.titles, titlesLoading, values?.orderLine, values?.title]);

--- a/src/routes/SerialEditRoute/SerialEditRoute.js
+++ b/src/routes/SerialEditRoute/SerialEditRoute.js
@@ -85,14 +85,12 @@ const SerialEditRoute = () => {
       onSubmit={submitSerial}
     >
       {({ handleSubmit }) => (
-        <form onSubmit={handleSubmit}>
-          <SerialForm
-            handlers={{
-              onClose: handleClose,
-              onSubmit: handleSubmit,
-            }}
-          />
-        </form>
+        <SerialForm
+          handlers={{
+            onClose: handleClose,
+            onSubmit: handleSubmit,
+          }}
+        />
       )}
     </ERMForm>
   );

--- a/src/routes/SerialEditRoute/SerialEditRoute.js
+++ b/src/routes/SerialEditRoute/SerialEditRoute.js
@@ -66,6 +66,7 @@ const SerialEditRoute = () => {
   if (isLoading) {
     return <LoadingView dismissible onClose={handleClose} />;
   }
+
   return (
     <ERMForm
       initialValues={{
@@ -73,6 +74,10 @@ const SerialEditRoute = () => {
         ...(!!serial?.orderLine && {
           orderLine: {
             ...serial?.orderLine?.remoteId_object,
+            /* This object (titleObject) is used later and a useEffect inserts into form state,
+             * so any changes to this state shape need to be reflected in the useEffect
+             * in POLineForm.
+             */
             titleObject: {
               title: serial?.orderLine?.title,
               id: serial?.orderLine?.titleId,


### PR DESCRIPTION
`POLineForm` useEffect was glueing an object into form state which did not match the shape set up in `initialValues`, causing the form state to always be "dirty" on first mount