### PR TITLE
fix: Minor chronology locale tweaks

### DIFF
--- a/src/components/RulesetFormSections/LabelFieldArray/LabelFieldArray.js
+++ b/src/components/RulesetFormSections/LabelFieldArray/LabelFieldArray.js
@@ -2,7 +2,14 @@ import { FieldArray } from 'react-final-form-arrays';
 import { useFormState, Field, useForm } from 'react-final-form';
 import { FormattedMessage } from 'react-intl';
 
-import { Button, Select, Row, Col, TextArea, Selection } from '@folio/stripes/components';
+import {
+  Button,
+  Select,
+  Row,
+  Col,
+  TextArea,
+  Selection,
+} from '@folio/stripes/components';
 import {
   EditCard,
   requiredValidator,
@@ -81,10 +88,16 @@ const LabelFieldArray = () => {
                     change(`templateConfig.rules[${index}]`, {
                       templateMetadataRuleType: e?.target?.value,
                     });
-                    change(
-                      `templateConfig.rules[${index}].ruleType`,
-                      undefined
-                    );
+                    if (e?.target?.value === 'chronology') {
+                      change(`templateConfig.rules[${index}].ruleType`, {
+                        ruleLocale: 'en',
+                      });
+                    } else {
+                      change(
+                        `templateConfig.rules[${index}].ruleType`,
+                        undefined
+                      );
+                    }
                   }}
                   required
                 />
@@ -132,9 +145,10 @@ const LabelFieldArray = () => {
                         }
                         meta={meta}
                         onChange={(e) => {
-                          change(`templateConfig.rules[${index}].ruleType`, {
-                            templateMetadataRuleFormat: e?.target?.value,
-                          });
+                          change(
+                            `templateConfig.rules[${index}].ruleType.templateMetadataRuleFormat`,
+                            e?.target?.value
+                          );
                           change(
                             `templateConfig.rules[${index}].ruleType.ruleFormat`,
                             undefined
@@ -156,18 +170,21 @@ const LabelFieldArray = () => {
                   validate={requiredValidator}
                 />
               </Col>
-              <Col xs={3}>
-                <Field
-                  component={Selection}
-                  dataOptions={locales}
-                  label="Locale"
-                  name={`templateConfig.rules[${index}].ruleType.ruleLocale`}
-                  onFilter={filterSelectValues}
-                  parse={(v) => v}
-                  required
-                  validate={requiredValidator}
-                />
-              </Col>
+              {values?.templateConfig?.rules[index]
+                ?.templateMetadataRuleType === 'chronology' && (
+                <Col xs={3}>
+                  <Field
+                    component={Selection}
+                    dataOptions={locales}
+                    label="Locale"
+                    name={`templateConfig.rules[${index}].ruleType.ruleLocale`}
+                    onFilter={filterSelectValues}
+                    parse={(v) => v}
+                    required
+                    validate={requiredValidator}
+                  />
+                </Col>
+              )}
             </>
           )}
         </Row>


### PR DESCRIPTION
Add default to English, Persist the value even as the user changes the Chronology format, removed from enumeration formats