### PR TITLE
UISER-133: Bring UI permissions in line with backend permission naming

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "visible": true,
         "subPermissions": [
           "ui-serials-management.serials.view",
-          "serials-management.predictedPieces.view"
+          "serials-management.predictedPieceSets.view"
         ]
       },
       {
@@ -115,7 +115,7 @@
         "visible": true,
         "subPermissions": [
           "ui-serials-management.predictedpieces.view",
-          "serials-management.predictedPieces.edit"
+          "serials-management.predictedPieceSets.edit"
         ]
       },
       {


### PR DESCRIPTION
Backend permissions were renamed by MODSER-35, but this did not update permissions referenced in UI. This PR corrects this