### PR TITLE
UISER-133: Use correct UI permissions for displaying UI elements

### DIFF
--- a/src/components/views/SerialView/SerialView.js
+++ b/src/components/views/SerialView/SerialView.js
@@ -85,7 +85,7 @@ const SerialView = ({
 
   const renderActionMenu = () => {
     const buttons = [];
-    if (stripes.hasPerm('serials-management.serials.edit')) {
+    if (stripes.hasPerm('ui-serials-management.serials.edit')) {
       buttons.push(
         <Button
           key="edit-serial"
@@ -98,7 +98,7 @@ const SerialView = ({
           </Icon>
         </Button>
       );
-      if (stripes.hasPerm('serials-management.predictedPieces.edit')) {
+      if (stripes.hasPerm('ui-serials-management.predictedPieces.edit')) {
         buttons.push(
           <Button
             key="generate-pieces"


### PR DESCRIPTION
Replacing use of backend permissions (one of which no longer exists with the same name) have been used to conditionally render UI elements. UI permissions used in stead