### PR TITLE
UISER-133: Incorrect predictedPieces permission case

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
         ]
       },
       {
-        "permissionName": "ui-serials-management.predictedpieces.view",
+        "permissionName": "ui-serials-management.predictedPieces.view",
         "displayName": "Serials: Search & view predicted pieces",
         "description": "Grants all permissions included in Serials: Search & view serials plus the ability to search and view predicted pieces.",
         "visible": true,
@@ -109,12 +109,12 @@
         ]
       },
       {
-        "permissionName": "ui-serials-management.predictedpieces.edit",
+        "permissionName": "ui-serials-management.predictedPieces.edit",
         "displayName": "Serials: Create predicted pieces",
         "description": "Grants all permissions included in Serials: Search & view predicted pieces plus the ability to creatre predicted pieces based on publication patterns.",
         "visible": true,
         "subPermissions": [
-          "ui-serials-management.predictedpieces.view",
+          "ui-serials-management.predictedPieces.view",
           "serials-management.predictedPieceSets.edit"
         ]
       },

--- a/src/components/views/SerialView/SerialView.js
+++ b/src/components/views/SerialView/SerialView.js
@@ -98,7 +98,7 @@ const SerialView = ({
           </Icon>
         </Button>
       );
-      if (stripes.hasPerm('ui-serials-management.predictedPieces.edit')) {
+      if (stripes.hasPerm('ui-serials-management.predictedpieces.edit')) {
         buttons.push(
           <Button
             key="generate-pieces"

--- a/src/components/views/SerialView/SerialView.js
+++ b/src/components/views/SerialView/SerialView.js
@@ -98,7 +98,7 @@ const SerialView = ({
           </Icon>
         </Button>
       );
-      if (stripes.hasPerm('ui-serials-management.predictedpieces.edit')) {
+      if (stripes.hasPerm('ui-serials-management.predictedPieces.edit')) {
         buttons.push(
           <Button
             key="generate-pieces"


### PR DESCRIPTION
Tweaked use of hasPerm for ui-serials-management.predictedPieces permission, as all perms are changed to lower case