### PR TITLE
Release 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
   * UISER-31 Missing permission serials-management.locales.collection.get from module.serials-management.enabled perm set
   * Translations
 
+## 1.0.3 2024-05-10
+  * UISER-31 Missing permission serials-management.locales.collection.get from module.serials-management.enabled perm set
+  * Translations
+
 ## 1.0.2 2024-04-26
   * UISER-27 Ensure meaningful aria labels are in place to uniquely identify repeated fields
   * Translations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # change history for ui-serials-management
 
-## 1.0.3 2024-05-10
-  * UISER-31 Missing permission serials-management.locales.collection.get from module.serials-management.enabled perm set
-  * Translations
+## 1.0.4 2024-05-15
+  * UISER-133 Permissions not renamed in line with updated backend perms
 
 ## 1.0.3 2024-05-10
   * UISER-31 Missing permission serials-management.locales.collection.get from module.serials-management.enabled perm set

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "visible": true,
         "subPermissions": [
           "ui-serials-management.serials.view",
-          "serials-management.predictedPieces.view"
+          "serials-management.predictedPieceSets.view"
         ]
       },
       {
@@ -115,7 +115,7 @@
         "visible": true,
         "subPermissions": [
           "ui-serials-management.predictedpieces.view",
-          "serials-management.predictedPieces.edit"
+          "serials-management.predictedPieceSets.edit"
         ]
       },
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/serials-management",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "FOLIO app for serials-management",
   "main": "src/index.js",
   "repository": "folio-org/ui-serials-management",

--- a/src/components/views/SerialView/SerialView.js
+++ b/src/components/views/SerialView/SerialView.js
@@ -85,7 +85,7 @@ const SerialView = ({
 
   const renderActionMenu = () => {
     const buttons = [];
-    if (stripes.hasPerm('serials-management.serials.edit')) {
+    if (stripes.hasPerm('ui-serials-management.serials.edit')) {
       buttons.push(
         <Button
           key="edit-serial"
@@ -98,7 +98,7 @@ const SerialView = ({
           </Icon>
         </Button>
       );
-      if (stripes.hasPerm('serials-management.predictedPieces.edit')) {
+      if (stripes.hasPerm('ui-serials-management.predictedpieces.edit')) {
         buttons.push(
           <Button
             key="generate-pieces"


### PR DESCRIPTION
Added sections to changelog reflected in 1.0.3 released
Backend permissions were renamed by MODSER-35, but this did not update permissions referenced in UI. This PR corrects this
