### PR TITLE
chore: Workflow tweaks

### DIFF
--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -13,7 +13,10 @@
 
 
 name: buildNPM Snapshot
-on: [push, pull_request]
+on: 
+  pull_request:
+  push:
+    branches: [master]
 
 jobs:
   github-actions-ci:

--- a/.github/workflows/stuck-license-cla.yml
+++ b/.github/workflows/stuck-license-cla.yml
@@ -1,0 +1,19 @@
+name: stuckLicenseCLA
+on:
+  pull_request:
+    types: [opened]
+
+## Adapted from github discussion comment https://github.com/orgs/community/discussions/69944#discussioncomment-7281028
+jobs:
+  github-actions-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create License CLA comment
+        run: |
+          # Use GitHub API to create a comment on the PR
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          COMMENT="[License CLA Stuck?](https://cla-assistant.io/check/${{ github.repository }}?pullRequest=${PR_NUMBER}) (Developer should make sure that it is really stuck before clicking)"
+          GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          COMMENT_URL="https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments"
+
+          curl -s -H "Authorization: token ${GITHUB_TOKEN}" -X POST $COMMENT_URL -d "{\"body\":\"$COMMENT\"}"


### PR DESCRIPTION
Added stuck license cla button comment workflow, Prevent buildNPM Snapshot having to run twice on PRs