### PR TITLE
Release 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # change history for ui-serials-management
 
+## 1.0.5 2024-08-23
+  * UISER-129 Add "Create item" checkbox to "Generate in receiving" dialog
+
 ## 1.0.4 2024-05-15
   * UISER-133 Permissions not renamed in line with updated backend perms
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/serials-management",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "FOLIO app for serials-management",
   "main": "src/index.js",
   "repository": "folio-org/ui-serials-management",

--- a/src/components/GenerateReceivingModal/GenerateReceivingModal.js
+++ b/src/components/GenerateReceivingModal/GenerateReceivingModal.js
@@ -63,7 +63,9 @@ const GenerateReceivingModal = ({
       'GeneratingReceivingModal',
       'submitReceivingPiece',
     ],
-    (data) => ky.post(RECEIVING_PIECES_ENDPOINT, { json: data?.receiving }).json()
+    (data) => {
+      return ky.post(`${RECEIVING_PIECES_ENDPOINT}${data?.createItem ? '?createItem=true' : ''}`, { json: data?.receiving }).json();
+    }
   );
 
   const { mutateAsync: submitReceivingIds } = useMutation(
@@ -155,6 +157,7 @@ const GenerateReceivingModal = ({
         };
 
       return {
+        ...values?.createItem && { createItem: values.createItem },
         receiving: {
           poLineId: serial?.orderLine?.remoteId,
           titleId: serial?.orderLine?.titleId,
@@ -351,6 +354,23 @@ const GenerateReceivingModal = ({
               )}
             </FormattedMessage>
           </Col>
+          {serial?.orderLine?.remoteId_object?.physical?.createInventory === 'Instance, Holding, Item' && (
+            <Col xs={3}>
+              <Label>
+                <FormattedMessage id="ui-serials-management.pieceSets.createItem" />
+              </Label>
+              <FormattedMessage id="ui-serials-management.pieceSets.createItem">
+                {([ariaLabel]) => (
+                  <Field
+                    aria-label={ariaLabel}
+                    component={Checkbox}
+                    name="createItem"
+                    type="checkbox"
+                  />
+                )}
+              </FormattedMessage>
+            </Col>
+          )}
         </Row>
         <Row>
           {!!serial?.orderLine?.remoteId_object?.locations?.length && (

--- a/translations/ui-serials-management/en.json
+++ b/translations/ui-serials-management/en.json
@@ -226,6 +226,7 @@
   "pieceSets.generateReceivingInfo" : "Selecting 'Generate receiving pieces' will create new pieces in the Receiving app. Please wait while the pieces are generated. This window will close when the process is complete.",
   "pieceSets.countReceivingGenerated": "<strong>{count} receiving pieces were generated.</strong> Please check this total is as expected. The pieces can now be viewed in the Receiving app.",
   "pieceSets.generateReceivingErrorMessage": "<strong>Error:</strong> No receiving pieces were generated. ",
+  "pieceSets.createItem": "Create item",
 
   "validate.withinRange": "Must be within range {minValue} and {maxValue}",
   "validate.notNegative": "Cannot be negative",


### PR DESCRIPTION
* feat: Add "Create item" checkbox to "Generate in receiving" dialog

Added "Create item" checkbox to recieving pieces modal, as this was not in seperate commits, this part has been cherry picked from the original [UISER-129 PR](https://github.com/folio-org/ui-serials-management/commit/3554ba4f47c9aec7504d2f01907f4ff287648022) 

* chore: Release 1.0.5

Updated app version to 1.0.5 and added section to changelog

UISER-156

