### PR TITLE
MODSER-57: Generate pieces deprecation handling

### DIFF
--- a/src/components/PiecesPreviewModal/PiecesPreviewModal.js
+++ b/src/components/PiecesPreviewModal/PiecesPreviewModal.js
@@ -15,7 +15,7 @@ import {
   MultiColumnList,
 } from '@folio/stripes/components';
 
-import { rulesetSubmitValuesHandler, urls } from '../utils';
+import { rulesetSubmitValuesHandler, urls, sortPieces } from '../utils';
 
 import {
   CREATE_PREDICTED_PIECES,
@@ -62,7 +62,14 @@ const PiecesPreviewModal = ({
     (data) => ky
       .post(GENERATE_PIECES_PREVIEW, { json: data })
       .json()
-      .then((res) => setGeneratedPieceSet(res))
+      .then((res) => {
+        if (!Array.isArray(res)) {
+          const sortedPieceSet = { ...res, pieces: sortPieces(res?.pieces) };
+          setGeneratedPieceSet(sortedPieceSet);
+        } else {
+          setGeneratedPieceSet(res);
+        }
+      })
   );
 
   // istanbul ignore next

--- a/src/components/PiecesPreviewModal/PiecesPreviewModal.js
+++ b/src/components/PiecesPreviewModal/PiecesPreviewModal.js
@@ -209,7 +209,14 @@ const PiecesPreviewModal = ({
             columnWidths={{
               publicationDate: { min: 100, max: 165 },
             }}
-            contentData={generatedPieceSet}
+            // DEPRECATED - This handles the older case in which generatePieces responded with an array of pieces
+            // Now supports newer response of the predicted piece set object, containing an array of pieces
+            // TODO Remove this once interface version has been increased
+            contentData={
+              Array.isArray(generatedPieceSet)
+                ? generatedPieceSet
+                : generatedPieceSet?.pieces
+            }
             formatter={formatter}
             id="pieces-preview-multi-columns"
             interactive={false}

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -8,4 +8,4 @@ export { default as focusSASQSearchField } from './focusSASQSearchField';
 export { default as getSortedItems } from './getSortedItems';
 export { default as deepDeleteKeys } from './deepDeleteKeys';
 export { default as rulesetSubmitValuesHandler } from './rulesetSubmitValuesHandler';
-
+export { default as sortPieces } from './sortPieces';

--- a/src/components/utils/sortPieces.js
+++ b/src/components/utils/sortPieces.js
@@ -1,0 +1,29 @@
+import { INTERNAL_COMBINATION_PIECE } from '../../constants/internalPieceClasses';
+
+// Used to sort pieces by date and combination pieces by their recurrence pieces date
+const sortPieces = (pieces) => {
+  // Itereate through the pieces and find combination pieces
+  return pieces
+    ?.map((p) => {
+      return p?.class === INTERNAL_COMBINATION_PIECE
+        ? {
+          ...p,
+          // Sort combination piece's recurrence pieces by date
+          recurrencePieces: p?.recurrencePieces?.sort((a, b) => (a?.date < b?.date ? -1 : 1)),
+        }
+        : p;
+    })
+    .sort((a, b) => {
+      // Sort all pieces by date or by the recurrence pieces of a combination piece
+      return (a?.class === INTERNAL_COMBINATION_PIECE
+        ? a?.recurrencePieces[0]?.date
+        : a?.date) <
+        (b?.class === INTERNAL_COMBINATION_PIECE
+          ? b?.recurrencePieces[0]?.date
+          : b?.date)
+        ? -1
+        : 1;
+    });
+};
+
+export default sortPieces;

--- a/src/components/views/PieceSetView/PieceSetView.js
+++ b/src/components/views/PieceSetView/PieceSetView.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
@@ -19,8 +19,7 @@ import {
   SERIAL_ENDPOINT,
   PIECE_SET_ENDPOINT,
 } from '../../../constants/endpoints';
-import { INTERNAL_COMBINATION_PIECE } from '../../../constants/internalPieceClasses';
-import { urls } from '../../utils';
+import { urls, sortPieces } from '../../utils';
 
 const propTypes = {
   onClose: PropTypes.func.isRequired,
@@ -81,28 +80,7 @@ const PieceSetView = ({
     }
   };
 
-  const sortedPieces = pieceSet?.pieces
-    // Itereate through the pieces and find combination pieces
-    ?.map((p) => {
-      return p?.class === INTERNAL_COMBINATION_PIECE
-        ? {
-          ...p,
-          // Sort combination piece's recurrence pieces by date
-          recurrencePieces: p?.recurrencePieces?.sort((a, b) => (a?.date < b?.date ? -1 : 1)),
-        }
-        : p;
-    })
-    .sort((a, b) => {
-      // Sort all pieces by date or by the recurrence pieces of a combination piece
-      return (a?.class === INTERNAL_COMBINATION_PIECE
-        ? a?.recurrencePieces[0]?.date
-        : a?.date) <
-        (b?.class === INTERNAL_COMBINATION_PIECE
-          ? b?.recurrencePieces[0]?.date
-          : b?.date)
-        ? -1
-        : 1;
-    });
+  const sortedPieces = useMemo(() => sortPieces(pieceSet?.pieces), [pieceSet]);
 
   const getSectionProps = (name) => {
     return {


### PR DESCRIPTION
Added conditional when passing genrated pieces to pieces list, older versions of the  backend fetched an array of pieces, whereas the new endpoint returns a predicted piece set, this conditional sorts if the enpoint is either an object or an array

Merge after mod-serials-management [PR #117](https://github.com/folio-org/mod-serials-management/pull/117)