### PR TITLE
MODSER-58: Start date changes

### DIFF
--- a/src/components/PiecesPreviewModal/PiecesPreviewModalForm.js
+++ b/src/components/PiecesPreviewModal/PiecesPreviewModalForm.js
@@ -69,7 +69,7 @@ const PiecesPreviewModalForm = ({
     change('', {
       startDate: getAdjustedStartDate(selectedPieceSet?.startDate),
       startingValues:
-        selectedPieceSet?.nextPieceTemplateMetadata?.userConfigured?.map(
+        selectedPieceSet?.continuationPieceRecurrenceMetadata?.userConfigured?.map(
           (uc) => {
             if (uc?.metadataType?.levels?.length) {
               return {

--- a/src/components/PiecesPreviewModal/PiecesPreviewModalForm.js
+++ b/src/components/PiecesPreviewModal/PiecesPreviewModalForm.js
@@ -41,27 +41,35 @@ const PiecesPreviewModalForm = ({
   const { change } = useForm();
   const intl = useIntl();
 
+  const getAdjustedStartDate = (date) => {
+    const adjustedStartDate = new Date(date);
+    adjustedStartDate.setFullYear(adjustedStartDate.getFullYear() + 1);
+    return adjustedStartDate;
+  };
+
   const startingValueDataOptions = existingPieceSets
     ?.filter((ps) => ps?.ruleset?.id === ruleset?.id)
     ?.map((fps) => {
+      const adjustedStartDate = new Date(fps?.startDate);
+      adjustedStartDate.setFullYear(adjustedStartDate.getFullYear() + 1);
       return {
         value: fps?.id,
         label: `${intl.formatMessage({ id: 'ui-serials-management.pieceSets.publicationDate' })}:
-                ${intl.formatDate(fps?.nextPieceTemplateMetadata?.standard?.date)},
+                ${intl.formatDate(getAdjustedStartDate(fps?.startDate))},
                 ${intl.formatMessage({ id: 'ui-serials-management.pieceSets.dateGenerated' })}:
                 ${intl.formatDate(fps?.dateCreated)} ${intl.formatTime(fps?.dateCreated)} `,
       };
     });
 
   const handleStartingValuesChange = (e) => {
-    const selectedNextPiece = existingPieceSets?.find(
+    const selectedPieceSet = existingPieceSets?.find(
       (ps) => ps.id === e?.target?.value || ''
     );
     // When changes fields at the top level of the form, change function requires an empty string, funky
     change('', {
-      startDate: selectedNextPiece?.nextPieceTemplateMetadata?.standard?.date,
+      startDate: getAdjustedStartDate(selectedPieceSet?.startDate),
       startingValues:
-        selectedNextPiece?.nextPieceTemplateMetadata?.userConfigured?.map(
+        selectedPieceSet?.nextPieceTemplateMetadata?.userConfigured?.map(
           (uc) => {
             if (uc?.metadataType?.levels?.length) {
               return {


### PR DESCRIPTION
- Changed startDate field and select options date to be the piecesets startdate plus a year as opposed to the nextPiece date
- Changed the property nextPieceTemplateMetadata to continuationPieceRecurrenceMetadata in line with backend changes