### PR TITLE
build: stripes-erm-testing version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "@folio/stripes": "^9.2.0",
     "@folio/stripes-cli": "^3.2.0",
     "@folio/stripes-erm-components": "^9.2.0",
-    "@folio/stripes-erm-testing": "^2.2.1",
+    "@folio/stripes-erm-testing": "^3.0.0",
     "@formatjs/cli": "^6.1.3",
     "core-js": "^3.6.1",
     "eslint": "^7.32.0",


### PR DESCRIPTION
Bumped stripes-erm-testing to version 3.0.0, whilst not released currently there are some helpers which will be used in other PRs, plus seperating this out into its own commit will potentially help us down th line