### PR TITLE
UISER-196: ModelRuleset locale values

### DIFF
--- a/src/components/RulesetFormSections/ChronologyFieldArray/ChronologyFieldArray.js
+++ b/src/components/RulesetFormSections/ChronologyFieldArray/ChronologyFieldArray.js
@@ -105,7 +105,9 @@ const ChronologyFieldArray = () => {
               <Field
                 component={Selection}
                 dataOptions={locales}
-                initialValue="en"
+                // This was causing an issue with model rulesets as the field initialValue prop was overriting the form state initialValues
+                // If on initialisation the rule is passed a ruleLocale, then dont use an initial value, otherwise use 'en'
+                initialValue={chronologyRule?.ruleLocale ? undefined : 'en'}
                 label={
                   <FormattedMessage id="ui-serials-management.ruleset.chronology.locale" />
                 }


### PR DESCRIPTION
When using publication templates with chronologies with a locale specified, the locale in the template is not used when applying the template to create a new publication pattern

UISER-196