### PR TITLE
UISER-204: Textual enumeration labels are not populated in edit/copy screens

### DIFF
--- a/src/components/RulesetFormSections/EnumerationFieldArray/EnumerationTextualFieldArray/EnumerationTextualFieldArray.js
+++ b/src/components/RulesetFormSections/EnumerationFieldArray/EnumerationTextualFieldArray/EnumerationTextualFieldArray.js
@@ -35,7 +35,7 @@ const EnumerationTextualFieldArray = ({ name, index }) => {
 
   const refdataOptions =
     refdata?.map((e) => {
-      return { label: e?.desc, value: e?.desc };
+      return { label: e?.desc, value: e?.id };
     }) ?? [];
 
   const tokenText = `{{enumeration${index + 1}}}`;
@@ -71,7 +71,7 @@ const EnumerationTextualFieldArray = ({ name, index }) => {
       <Row>
         <Col xs={3}>
           <Field
-            name={`${name}.refdataCategory.desc`}
+            name={`${name}.refdataCategory.id`}
             render={({ input, meta }) => (
               <Select
                 dataOptions={[{ label: '', value: '' }, ...refdataOptions]}
@@ -129,7 +129,7 @@ const EnumerationTextualFieldArray = ({ name, index }) => {
               dataOptions={
                   refdata
                     ?.find(
-                      (e) => e?.desc === get(values, `${name}.refdataCategory.desc`, null)
+                      (e) => e?.id === get(values, `${name}.refdataCategory.id`, null)
                     )
                     ?.values.map((e) => {
                       return { label: e?.label, value: e?.id };

--- a/src/components/RulesetSections/EnumerationLabels/EnumerationLabels.js
+++ b/src/components/RulesetSections/EnumerationLabels/EnumerationLabels.js
@@ -141,7 +141,7 @@ const EnumerationLabels = ({ ruleset }) => {
                     <Col xs={12}>
                       {renderEnumerationLabelName(rule, ruleIndex)}
                     </Col>
-                    <Col xs={3}>
+                    <Col xs={6}>
                       <KeyValue
                         label={
                           <FormattedMessage id="ui-serials-management.ruleset.picklist" />

--- a/src/components/utils/getRulesetFormValues.js
+++ b/src/components/utils/getRulesetFormValues.js
@@ -5,8 +5,38 @@ import deepDeleteKeys from './deepDeleteKeys';
  * @param {Object} ruleset - The ruleset data to be transformed.
  * @returns {Object} - The transformed ruleset as initial form values, with specific keys removed.
  */
-
 const getRulesetFormValues = (ruleset) => {
+  // TODO This uitl needs to be refactored as it no longer serves its original purpose
+  // We orinally mapped all refdataValues using .value but with the textual enumeration levels now uising id
+  // This means that deep deleting the keys will not work as expected
+  const keysToDelete = ['id', 'label', 'dateCreated', 'lastUpdated', 'owner'];
+
+  // As we map refdataCategory and refdataValue by ID, we dont want these values deep deleted
+  const enumerationRules = ruleset?.templateConfig?.enumerationRules?.map(
+    (rule) => {
+      if (rule?.templateMetadataRuleFormat?.value === 'enumeration_textual') {
+        return {
+          index: rule?.index,
+          templateMetadataRuleFormat: rule?.templateMetadataRuleFormat?.value,
+          ruleFormat: {
+            refdataCategory: { id: rule?.ruleFormat?.refdataCategory?.id },
+            levels: rule?.ruleFormat?.levels?.map((level) => ({
+              index: level?.index,
+              units: level?.units,
+              refdataValue: { id: level?.refdataValue?.id },
+              internalNote: level?.internalNote,
+            })),
+          },
+        };
+      } else {
+        return {
+          ...deepDeleteKeys(rule, keysToDelete),
+          templateMetadataRuleFormat: rule?.templateMetadataRuleFormat?.value,
+        };
+      }
+    }
+  );
+
   const initialValues = {
     ...ruleset,
     recurrence: ruleset?.recurrence,
@@ -44,9 +74,11 @@ const getRulesetFormValues = (ruleset) => {
     },
   };
 
-  const keysToDelete = ['id', 'label', 'dateCreated', 'lastUpdated', 'owner'];
-
-  return deepDeleteKeys(initialValues, keysToDelete);
+  const formattedValues = deepDeleteKeys(initialValues, keysToDelete);
+  return {
+    ...formattedValues,
+    templateConfig: { ...formattedValues.templateConfig, enumerationRules },
+  };
 };
 
 export default getRulesetFormValues;


### PR DESCRIPTION
As we use a util function which deep deletes the id key from a ruleset when converting from persistent data to form values, the textual level data was incorrect, additionally ound an issue in which mapping the refdataCategory by desc meant that a new refdataCategory was being created, so mved over to using ID

UISER-204