### PR TITLE
fix: formateDate timezone inclusion

### DIFF
--- a/src/components/PiecesPreviewModal/PiecesPreviewModal.js
+++ b/src/components/PiecesPreviewModal/PiecesPreviewModal.js
@@ -287,7 +287,9 @@ const PiecesPreviewModal = ({
             id="ui-serials-management.pieceSets.overlappingDates.dialog"
             values={{
               br: <br />,
-              startDate: intl.formatDate(confirmationModal?.values?.startDate),
+              startDate: intl.formatDate(confirmationModal?.values?.startDate, {
+                timeZone: 'UTC',
+              }),
               serialName,
             }}
           />

--- a/src/components/PiecesPreviewModal/PiecesPreviewModalForm/PiecesPreviewModalForm.js
+++ b/src/components/PiecesPreviewModal/PiecesPreviewModalForm/PiecesPreviewModalForm.js
@@ -100,7 +100,7 @@ const PiecesPreviewModalForm = ({
       return {
         value: fps?.id,
         label: `${intl.formatMessage({ id: 'ui-serials-management.pieceSets.publicationDate' })}:
-                ${intl.formatDate(getAdjustedStartDate(fps?.startDate, fps?.numberOfCycles ?? 1))},
+                ${intl.formatDate(getAdjustedStartDate(fps?.startDate, fps?.numberOfCycles ?? 1), { timeZone: 'UTC' })},
                 ${intl.formatMessage({ id: 'ui-serials-management.pieceSets.dateGenerated' })}:
                 ${intl.formatDate(fps?.dateCreated)} ${intl.formatTime(fps?.dateCreated)} `,
       };
@@ -307,7 +307,9 @@ const PiecesPreviewModalForm = ({
           <FormattedMessage
             id="ui-serials-management.pieceSets.overlappingDates.warning"
             values={{
-              startDate: intl.formatDate(values?.startDate),
+              startDate: intl.formatDate(values?.startDate, {
+                timeZone: 'UTC',
+              }),
               serialName,
             }}
           />

--- a/src/components/PiecesPreviewModal/PiecesPreviewModalForm/PiecesPreviewModalForm.test.js
+++ b/src/components/PiecesPreviewModal/PiecesPreviewModalForm/PiecesPreviewModalForm.test.js
@@ -9,7 +9,6 @@ import {
 } from '@folio/stripes-erm-testing';
 
 import {
-  screen,
   waitFor,
 } from '@folio/jest-config-stripes/testing-library/react';
 
@@ -76,10 +75,13 @@ describe('PiecesPreviewModalForm', () => {
 
     describe('when an existing pieceset is selected from the "Follow on from the last piece in a previous set" select component', () => {
       beforeEach(async () => {
-        screen.debug();
-        await Select('Follow on from the last piece in a previous set').choose(
-          'Publication date: 2/1/2025, Date generated: 2/26/2024 10:02 AM'
-        );
+        await waitFor(async () => {
+          await Select(
+            'Follow on from the last piece in a previous set'
+          ).choose(
+            'Publication date: 2/1/2025, Date generated: 2/26/2024 10:02 AM'
+          );
+        });
       });
 
       test('datepicker start date renders expected date', async () => {


### PR DESCRIPTION
Following on from the previous UISER-211 commit,  we missed a few places in which we use the react-intl format date api and have forgotten to include the timezeon

UISER-211