### PR TITLE
UISER-205: ECS enable generation of receiving pieces from Serials Management when not in the primary tenant

### DIFF
--- a/src/components/GenerateReceivingModal/GenerateReceivingModal/GenerateReceivingModal.js
+++ b/src/components/GenerateReceivingModal/GenerateReceivingModal/GenerateReceivingModal.js
@@ -5,7 +5,7 @@ import { useMutation, useQueryClient } from 'react-query';
 import { FormattedMessage } from 'react-intl';
 import { v4 as uuidv4 } from 'uuid';
 
-import { useOkapiKy, useCallout } from '@folio/stripes/core';
+import { useOkapiKy, useCallout, useStripes } from '@folio/stripes/core';
 
 import { FormModal } from '@k-int/stripes-kint-components';
 import { Button, ModalFooter, Spinner } from '@folio/stripes/components';
@@ -21,7 +21,7 @@ import GenerateReceivingModalInfo from '../GenerateReceivingModalInfo';
 
 import {
   PIECE_SET_ENDPOINT,
-  BATCH_RECEIVING_PIECES_ENDPOINT
+  BATCH_RECEIVING_PIECES_ENDPOINT,
 } from '../../../constants/endpoints';
 import {
   INTERNAL_COMBINATION_PIECE,
@@ -37,22 +37,33 @@ const propTypes = {
 
 const GenerateReceivingModal = ({ orderLine, open, onClose, pieceSet }) => {
   const ky = useOkapiKy();
+  const stripes = useStripes();
   const queryClient = useQueryClient();
   const callout = useCallout();
 
+  const activeTenantId = stripes.okapi.tenant;
+  const centralTenantId = stripes.user?.user?.consortium?.centralTenantId;
+
   // Hooks to be used within an environment when cental ordering is enabled
   const { enabled: isCentralOrderingEnabled } = useCentralOrderingSettings();
-  const { tenants = [] } = useConsortiumTenants({ enabled: isCentralOrderingEnabled });
-
-  const { holdings = [] } = useInstanceHoldingsQuery(orderLine?.remoteId_object?.instanceId, {
-    consortium: isCentralOrderingEnabled,
+  const { tenants = [] } = useConsortiumTenants({
+    enabled: isCentralOrderingEnabled,
   });
 
+  const { holdings = [] } = useInstanceHoldingsQuery(
+    orderLine?.remoteId_object?.instanceId,
+    {
+      consortium: isCentralOrderingEnabled,
+    },
+  );
+
   const locationQueryParams = useMemo(() => {
-    const locationIds = orderLine?.remoteId_object?.locations?.map(loc => loc.locationId).filter(Boolean);
+    const locationIds = orderLine?.remoteId_object?.locations
+      ?.map((loc) => loc.locationId)
+      .filter(Boolean);
 
     if (locationIds?.length > 0) {
-      return { query: locationIds.map(id => `id==${id}`).join(' or ') };
+      return { query: locationIds.map((id) => `id==${id}`).join(' or ') };
     }
     return {};
   }, [orderLine?.remoteId_object?.locations]);
@@ -65,30 +76,44 @@ const GenerateReceivingModal = ({ orderLine, open, onClose, pieceSet }) => {
 
   // Filter holdings by checking if holdingId exists in POL locations
   const filteredHoldings = useMemo(() => {
-    return holdings?.filter((h) => orderLine?.remoteId_object?.locations?.some((rol) => {
-      if (rol?.tenantId) {
-        return rol?.holdingId === h?.id && rol?.tenantId === h?.tenantId;
-      }
-      return rol?.holdingId === h?.id;
-    }));
-  }, [holdings, orderLine?.remoteId_object?.locations]);
+    return holdings?.filter((h) => {
+      return orderLine?.remoteId_object?.locations?.some((rol) => {
+        // If tenantIds are present we assume ECS is enabled, however if we are within a member tenant instead of central, this should be irrelevant
+        if (rol?.tenantId && activeTenantId === centralTenantId) {
+          return rol?.holdingId === h?.id && rol?.tenantId === h?.tenantId;
+        }
+        return rol?.holdingId === h?.id;
+      });
+    });
+  }, [
+    holdings,
+    orderLine?.remoteId_object?.locations,
+    activeTenantId,
+    centralTenantId,
+  ]);
 
   // Taking consortium holdings/locations and extracting the tenantIds within those from the list of tenants
   const filteredTenants = useMemo(() => {
     return (
       tenants?.filter(
         (t) => locations?.some((l) => l?.tenantId === t?.id) ||
-          filteredHoldings?.some((l) => l?.tenantId === t?.id)
+          filteredHoldings?.some((l) => l?.tenantId === t?.id),
       ) || []
     );
   }, [tenants, locations, filteredHoldings]);
 
   const { mutateAsync: submitReceivingPieces } = useMutation(
-    ['ui-serials-management', 'GeneratingReceivingModal', 'submitReceivingPieces'],
-    (data) => ky.post(
-      `${BATCH_RECEIVING_PIECES_ENDPOINT}${data.createItem ? '?createItem=true' : ''}`,
-      { json: { pieces: data.pieces } }
-    ).json()
+    [
+      'ui-serials-management',
+      'GeneratingReceivingModal',
+      'submitReceivingPieces',
+    ],
+    (data) => ky
+      .post(
+        `${BATCH_RECEIVING_PIECES_ENDPOINT}${data.createItem ? '?createItem=true' : ''}`,
+        { json: { pieces: data.pieces } },
+      )
+      .json(),
   );
 
   const { mutateAsync: submitReceivingIds } = useMutation(
@@ -113,7 +138,7 @@ const GenerateReceivingModal = ({ orderLine, open, onClose, pieceSet }) => {
           ),
         });
         onClose();
-      })
+      }),
   );
 
   const getInitialValues = () => {
@@ -160,7 +185,7 @@ const GenerateReceivingModal = ({ orderLine, open, onClose, pieceSet }) => {
         piece?.class === INTERNAL_COMBINATION_PIECE
           ? piece?.recurrencePieces[0]?.date
           : piece?.date,
-        values?.interval
+        values?.interval,
       ),
     };
 
@@ -185,18 +210,18 @@ const GenerateReceivingModal = ({ orderLine, open, onClose, pieceSet }) => {
   const handleGeneration = async (values) => {
     try {
       const piecesArray = (pieceSet?.pieces || [])
-        .filter(piece => piece?.class !== INTERNAL_OMISSION_PIECE)
-        .map(piece => {
+        .filter((piece) => piece?.class !== INTERNAL_OMISSION_PIECE)
+        .map((piece) => {
           const formattedPiece = formatReceivingPiece(piece, values);
           return { originalPiece: piece, formattedPiece };
         });
 
       await submitReceivingPieces({
-        pieces: piecesArray.map(p => p.formattedPiece),
+        pieces: piecesArray.map((p) => p.formattedPiece),
         createItem: values?.createItem,
       });
 
-      const updatedPieces = piecesArray.map(p => ({
+      const updatedPieces = piecesArray.map((p) => ({
         ...p.originalPiece,
         receivingPieces: [
           ...(p.originalPiece?.receivingPieces || []),
@@ -267,7 +292,9 @@ const GenerateReceivingModal = ({ orderLine, open, onClose, pieceSet }) => {
         holdings={filteredHoldings}
         locations={locations}
         orderLine={orderLine}
-        tenants={filteredTenants}
+        // Since the form component makes assumptions based on the presence of tenantIds within locations/holdings,
+        //  we need to provide an empty array in the scenario where ECS is enabled but we are within a member tenant instead of central
+        tenants={activeTenantId === centralTenantId ? filteredTenants : []}
       />
     </FormModal>
   );


### PR DESCRIPTION
When central ordering is activated the expectation is that orders can be created in the central tenant OR in member tenants. When an order is created in central tenant, it can be received in the central tenant or member tenant. When order created in member tenant, can only be received in the member tenant.

However, for orders created in member tenants for use with the serials app, the creation of receiving pieces is prevented because the UI is expecting an affiliation property that does not exist on orders originating in member tenants.

UISER-205