### PR TITLE
ci: Incremented node version for validate action

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,7 @@ jobs:
     needs: version-number
     uses: folio-org/.github/.github/workflows/ui-module-descriptor-generate.yml@v1
     with:
-      node-version: 20.x ## Doing these directly for now
+      node-version: 22.x ## Doing these directly for now
       folio-npm-registry: https://repository.folio.org/repository/npm-folioci/
       package-version: ${{ needs.version-number.outputs.version-number }}
   validate_module_descriptor:


### PR DESCRIPTION
Bumped node-version for validate github workflow from 20.x to 22.x