### PR TITLE
UISER-258: Warn user when they are going to create additional receiving pieces

### DIFF
--- a/src/components/GenerateReceivingModal/GenerateReceivingModalInfo/GenerateReceivingModalInfo.js
+++ b/src/components/GenerateReceivingModal/GenerateReceivingModalInfo/GenerateReceivingModalInfo.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 
 import { Row, Col, KeyValue, MessageBanner } from '@folio/stripes/components';
@@ -8,6 +9,7 @@ import {
   INTERNAL_OMISSION_PIECE,
   INTERNAL_RECURRENCE_PIECE,
 } from '../../../constants/internalPieceClasses';
+import { urls } from '../../utils';
 
 import css from './GenerateReceivingModalInfo.css';
 
@@ -31,11 +33,34 @@ const GenerateReceivingModalInfo = ({ orderLineLocations = [], pieceSet }) => {
     }
   };
 
+  const hasExistingReceiving = pieceSet?.pieces?.some(
+    (p) => p?.receivingPieces?.length >= 1
+  );
+
   return (
     <>
       <MessageBanner>
         <FormattedMessage id="ui-serials-management.pieceSets.generateReceivingInfo" />
       </MessageBanner>
+      {hasExistingReceiving && (
+        <>
+          <MessageBanner type="warning">
+            <FormattedMessage
+              id="ui-serials-management.pieceSets.receivingPiecesAlreadyExistWarning"
+              values={{
+                link: pieceSet?.titleId ? (
+                  <Link to={urls.receivingView(pieceSet.titleId)}>
+                    {pieceSet?.title}
+                  </Link>
+                ) : (
+                  pieceSet?.title
+                ),
+              }}
+            />
+          </MessageBanner>
+          <br />
+        </>
+      )}
       {!orderLineLocations?.length && (
         <>
           <MessageBanner type="warning">

--- a/src/components/GenerateReceivingModal/GenerateReceivingModalInfo/GenerateReceivingModalInfo.test.js
+++ b/src/components/GenerateReceivingModal/GenerateReceivingModalInfo/GenerateReceivingModalInfo.test.js
@@ -1,3 +1,5 @@
+import { MemoryRouter } from 'react-router-dom';
+
 import {
   renderWithIntl,
   KeyValue,
@@ -36,6 +38,12 @@ describe('GenerateReceivingModalInfo', () => {
     test('does not render the "No orderline locations or holdings" message', async () => {
       await MessageBanner(
         'There are no locations or holdings for the linked POL and receiving pieces will be created with no location or holding. To add a location or holding please update the PO line.'
+      ).absent();
+    });
+
+    test('does not render the "Receiving pieces already exist" warning', async () => {
+      await MessageBanner(
+        'Warning: Receiving pieces already exist for this predicted piece set. See Quiet times for more details.'
       ).absent();
     });
 
@@ -102,6 +110,43 @@ describe('GenerateReceivingModalInfo', () => {
       await KeyValue('First piece').has({
         value: '2025-01-01, Wednesday 1 January 2025',
       });
+    });
+  });
+
+  describe('render component with a pieceset that already has receiving pieces', () => {
+    const pieceSetWithReceiving = {
+      ...pieceSet,
+      pieces: pieceSet.pieces.map((piece, index) => (index === 0
+        ? { ...piece, receivingPieces: [{ receivingId: 'receiving-1' }] }
+        : piece)),
+    };
+
+    let renderComponent;
+    beforeEach(() => {
+      renderComponent = renderWithIntl(
+        <MemoryRouter>
+          <GenerateReceivingModalInfo
+            orderLineLocations={serial?.orderLine?.remoteId_object?.locations}
+            pieceSet={pieceSetWithReceiving}
+          />
+        </MemoryRouter>,
+        translationsProperties
+      );
+    });
+
+    test('renders the "Receiving pieces already exist" warning', async () => {
+      await MessageBanner(
+        'Warning: Receiving pieces already exist for this predicted piece set. See Quiet times for more details.'
+      ).exists();
+    });
+
+    test('renders a link to the title in receiving using the serial title as link text', async () => {
+      const { getByRole } = renderComponent;
+      const link = getByRole('link', { name: 'Quiet times' });
+      expect(link).toHaveAttribute(
+        'href',
+        `/receiving/${pieceSet.titleId}/view`
+      );
     });
   });
 });

--- a/translations/ui-serials-management/en.json
+++ b/translations/ui-serials-management/en.json
@@ -283,6 +283,7 @@
   "pieceSets.generateReceivingInfo": "Selecting 'Generate receiving pieces' will create new pieces in the Receiving app. Please wait while the pieces are generated. This window will close when the process is complete.",
   "pieceSets.countReceivingGenerated": "<strong>{count} receiving pieces were generated.</strong> Please check this total is as expected. The pieces can now be viewed in the Receiving app.",
   "pieceSets.generateReceivingErrorMessage": "<strong>Error:</strong> No receiving pieces were generated. ",
+  "pieceSets.receivingPiecesAlreadyExistWarning": "Warning: Receiving pieces already exist for this predicted piece set. See {link} for more details.",
   "pieceSets.createItem": "Create item",
   "pieceSets.displayToPublic": "Display to public",
   "pieceSets.overlappingDates.dialog": "A predicted piece set with the start date <strong>{startDate}</strong> already exists for the serial <strong>{serialName}</strong>. {br} Generating a new set will result in some overlap between piece sets. If this is acceptable select \"Generate\" to continue.",


### PR DESCRIPTION
It is valid for a user to create multiple receiving pieces from a single predicted piece as the library may receiving multiple copies of the same serial in the same or different location. However, to try to ensure that a user does not create unwanted additional receiving pieces by mistake, there should be a clear on-screen warning for the user when they start the process of creating a new set of receiving pieces for a predicted piece set where receiving pieces already exist